### PR TITLE
chore: update test date for erpnext codebase changes

### DIFF
--- a/beam/tests/setup.py
+++ b/beam/tests/setup.py
@@ -49,7 +49,9 @@ def before_test():
 def create_test_data():
 	settings = frappe._dict(
 		{
-			"day": datetime.date(int(frappe.defaults.get_defaults().get("fiscal_year")), 1, 1),
+			"day": datetime.date(
+				int(frappe.defaults.get_defaults().get("fiscal_year", datetime.datetime.now().year)), 1, 1
+			),
 			"company": frappe.defaults.get_defaults().get("company"),
 			"company_account": frappe.get_value(
 				"Account",
@@ -81,8 +83,12 @@ def create_test_data():
 	create_customers(settings)
 	create_items(settings)
 	create_boms(settings)
-	create_material_request(settings)
-	create_production_plan(settings)
+	prod_plan_from_doc = "Sales Order"
+	if prod_plan_from_doc == "Sales Order":
+		create_sales_order(settings)
+	else:
+		create_material_request(settings)
+	create_production_plan(settings, prod_plan_from_doc)
 
 
 def create_suppliers(settings):
@@ -314,6 +320,53 @@ def create_boms(settings):
 		b.submit()
 
 
+def create_sales_order(settings):
+	so = frappe.new_doc("Sales Order")
+	so.transaction_date = settings.day
+	so.customer = customers[0]
+	so.order_type = "Sales"
+	so.currency = "USD"
+	so.selling_price_list = "Bakery Wholesale"
+	so.append(
+		"items",
+		{
+			"item_code": "Ambrosia Pie",
+			"delivery_date": so.transaction_date,
+			"qty": 40,
+			"warehouse": "Baked Goods - APC",
+		},
+	)
+	so.append(
+		"items",
+		{
+			"item_code": "Double Plum Pie",
+			"delivery_date": so.transaction_date,
+			"qty": 40,
+			"warehouse": "Baked Goods - APC",
+		},
+	)
+	so.append(
+		"items",
+		{
+			"item_code": "Gooseberry Pie",
+			"delivery_date": so.transaction_date,
+			"qty": 10,
+			"warehouse": "Baked Goods - APC",
+		},
+	)
+	so.append(
+		"items",
+		{
+			"item_code": "Kaduka Key Lime Pie",
+			"delivery_date": so.transaction_date,
+			"qty": 10,
+			"warehouse": "Baked Goods - APC",
+		},
+	)
+	so.save()
+	so.submit()
+
+
 def create_material_request(settings):
 	mr = frappe.new_doc("Material Request")
 	mr.material_request_type = "Manufacture"
@@ -359,19 +412,29 @@ def create_material_request(settings):
 	mr.submit()
 
 
-def create_production_plan(settings):
+def create_production_plan(settings, prod_plan_from_doc):
 	pp = frappe.new_doc("Production Plan")
 	pp.posting_date = settings.day
 	pp.company = settings.company
-	pp.get_items_from = "Material Request"
-	pp.append(
-		"material_requests",
-		{
-			"material_request": frappe.get_last_doc("Material Request").name,
-		},
-	)
 	pp.combine_sub_items = 1
-	pp.get_mr_items()
+	if prod_plan_from_doc == "Sales Order":
+		pp.get_items_from = "Sales Order"
+		pp.append(
+			"sales_orders",
+			{
+				"sales_order": frappe.get_last_doc("Sales Order").name,
+			},
+		)
+		pp.get_items()
+	else:
+		pp.get_items_from = "Material Request"
+		pp.append(
+			"material_requests",
+			{
+				"material_request": frappe.get_last_doc("Material Request").name,
+			},
+		)
+		pp.get_mr_items()
 	for item in pp.po_items:
 		item.planned_start_date = settings.day
 	pp.get_sub_assembly_items()


### PR DESCRIPTION
Addresses #53 

I updated my local bench and reinstalled my site with this code using erpnext `v14.33.2` and frappe `v14.43.0` and there were no errors.

I kept the code to use a Material Request for the Production Plan in there in case we ever want to go back to that method.