### PR TITLE
[object Object] bug in Stock Entry

### DIFF
--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -225,8 +225,6 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 		if isinstance(action.get("target"), str) and "." in action.get("target"):
 			serialized_target = action.get("target").split(".")
 			action["target"] = target.get(serialized_target[1])
-		else:
-			action["target"] = target
 
 	return actions
 

--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -215,8 +215,6 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 					if "." in action.get("target"):
 						serialized_target = action.get("target").split(".")
 						action["target"] = target.get(serialized_target[1])
-					else:
-						action["target"] = target
 				return override_action
 
 	actions = frm.get(barcode_doc.doc.doctype, {}).get(context.frm, [])


### PR DESCRIPTION
https://github.com/agritheory/beam/issues/60

I was able to reproduce it in a delivery note, in this case it occurs when it is rescanned:

[dnbefore.webm](https://github.com/agritheory/beam/assets/4945122/bed6c727-94cb-4223-a90a-c7ed7389ae5e)



With the change in this PR:

[dnafter.webm](https://github.com/agritheory/beam/assets/4945122/f180ba60-afc9-4268-a6d1-b67a6d42ddb4)


In Stock Entry, the issue occurs sometimes when you scan for the first time, always in a second scan. Whit this changes:

[screencast-127.0.0.1_8001-2023.08.24-10_58_04.webm](https://github.com/agritheory/beam/assets/4945122/ca3de634-ab6f-4908-8490-ae6be7bc8113)
