### PR TITLE
ci: update release action user and email

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,3 +20,5 @@ jobs:
         uses: python-semantic-release/python-semantic-release@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_committer_name: AgriTheory
+          git_committer_email: support@agritheory.dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "beam"
 authors = [
-    { name = "AgriTheory", email = "support@agritheory.com"}
+    { name = "AgriTheory", email = "support@agritheory.dev"}
 ]
 description = "Barcode Scanning for ERPNext"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR updates the username and email in the Python Semantic Release GH action script. The default behavior was to use `github-actions@github.com` but because it isn't an actual account, it shows as 'Invalid email' / avatar in the repo when it's the latest commit.

The action script has read/write access, but the docs say the username/email need to be associated with the token used (for permissions). I see this as having two options for using the support@agritheory.dev email:

1) Add the email to the AgriTheory account (go to GitHub `Settings -> Emails -> Add email address`). I tested this on one of my repos using my associated AgriTheory dev email (vs primary gmail account) and it worked great
2) Create a separate GitHub account for the support email, give it read/write access to any repo we use it for in the GH action

⚠️ NOTE BEFORE MERGING ⚠️ - merging this PR will likely break the release workflow until the support email is (or is associated with) an actual GH account.