### PR TITLE
test: fix net qty and HU tests

### DIFF
--- a/beam/beam/handling_unit.py
+++ b/beam/beam/handling_unit.py
@@ -77,7 +77,7 @@ def validate_handling_unit_overconsumption(doc, method=None):
 	if doc.doctype == "Stock Entry" and doc.purpose == "Material Receipt":
 		return doc
 
-	qty_field = "actual_qty" if doc.doctype == "Stock Entry" else "stock_qty"
+	qty_field = "transfer_qty" if doc.doctype == "Stock Entry" else "stock_qty"
 
 	for row in doc.get("items"):
 		error = False
@@ -91,25 +91,18 @@ def validate_handling_unit_overconsumption(doc, method=None):
 		precision_denominator = 1 / pow(100, frappe.get_precision(row.doctype, qty_field))
 
 		if doc.doctype == "Stock Entry":
-			# incoming
-			if row.get("s_warehouse") and not row.get("t_warehouse"):
-				if abs(row.get(qty_field) - hu.stock_qty) != 0.0 and (
-					# (row.get(qty_field) - hu.stock_qty) < precision_denominator
-					(row.get(qty_field) - hu.stock_qty)
-					> precision_denominator
-				):
-					error = True
 			# outgoing
-			elif row.get("t_warehouse") and not row.get("s_warehouse"):
+			if row.get("t_warehouse") and not row.get("s_warehouse"):
 				if (
-					abs(hu.stock_qty - row.get(qty_field)) != 0.0
+					abs(hu.stock_qty - row.get(qty_field)) > 0.0
 					and (hu.stock_qty - row.get(qty_field) > precision_denominator)
 					and not row.is_scrap_item
 				):
 					error = True
-			else:  # transfer / same warehouse
-				if abs(hu.stock_qty - row.get(qty_field)) != 0.0 and (
-					hu.stock_qty - row.get(qty_field) < precision_denominator
+			else:  # incoming and transfer / same warehouse
+				if (
+					abs(hu.stock_qty - row.get(qty_field)) > 0.0
+					and hu.stock_qty - row.get(qty_field) < precision_denominator
 				):
 					error = True
 
@@ -122,7 +115,7 @@ def validate_handling_unit_overconsumption(doc, method=None):
 		if error == True:
 			frappe.throw(
 				frappe._(
-					f"Row #{row.idx}: Handling Unit for {row.item_code} cannot be more than {hu.stock_qty} {hu.stock_uom}. You have {row.get(qty_field)} {row.stock_uom}"
+					f"Row #{row.idx}: Handling Unit for {row.item_code} cannot be more than {hu.stock_qty:.1f} {hu.stock_uom}. You have {row.get(qty_field):.1f} {row.stock_uom}"
 				),
 				NegativeStockError,
 				title=frappe._("Insufficient Stock"),

--- a/beam/beam/handling_unit.py
+++ b/beam/beam/handling_unit.py
@@ -94,7 +94,9 @@ def validate_handling_unit_overconsumption(doc, method=None):
 			# incoming
 			if row.get("s_warehouse") and not row.get("t_warehouse"):
 				if abs(row.get(qty_field) - hu.stock_qty) != 0.0 and (
-					(row.get(qty_field) - hu.stock_qty) < precision_denominator
+					# (row.get(qty_field) - hu.stock_qty) < precision_denominator
+					(row.get(qty_field) - hu.stock_qty)
+					> precision_denominator
 				):
 					error = True
 			# outgoing

--- a/beam/beam/overrides/stock_entry.py
+++ b/beam/beam/overrides/stock_entry.py
@@ -95,7 +95,15 @@ def get_handling_unit_qty(voucher_no, handling_unit, warehouse):
 def validate_items_with_handling_unit(doc, method=None):
 	if doc.stock_entry_type != "Material Receipt":
 		for row in doc.items:
-			if (
+			if not frappe.get_value("Item", row.item_code, "enable_handling_unit"):
+				continue
+			elif row.is_scrap_item and not frappe.get_value(
+				"BOM Scrap Item",
+				{"item_code": row.item_code, "parent": doc.get("bom_no")},
+				"create_handling_unit",
+			):
+				continue
+			elif (
 				doc.stock_entry_type in ["Repack", "Manufacture"]
 				and not (row.t_warehouse or row.is_finished_item or row.is_scrap_item)
 				and not row.handling_unit

--- a/beam/hooks.py
+++ b/beam/hooks.py
@@ -135,11 +135,11 @@ doc_events = {
 	},
 	"Stock Entry": {
 		"validate": [
-			"beam.beam.overrides.stock_entry.validate_items_with_handling_unit"
 			# "beam.beam.handling_unit.validate_handling_unit_overconsumption",
 		],
 		"before_submit": [
 			"beam.beam.handling_unit.generate_handling_units",
+			"beam.beam.overrides.stock_entry.validate_items_with_handling_unit",
 		],
 	},
 	"Sales Invoice": {

--- a/beam/tests/setup.py
+++ b/beam/tests/setup.py
@@ -250,7 +250,7 @@ def create_items(settings):
 		i.stock_uom = item.get("uom")
 		i.description = item.get("description")
 		i.maintain_stock = 1
-		i.enable_handling_unit = 1
+		i.enable_handling_unit = 0 if i.item_code in ("Water", "Ice Water") else 1
 		i.include_item_in_manufacturing = 1
 		i.default_warehouse = settings.get("warehouse")
 		i.default_material_request_type = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     "python-barcode",
-    "pytest"
+    "pytest",
+    "pytest-order"
 ]
 
 [build-system]


### PR DESCRIPTION
Addresses #98 

- [x] Net quantity test (currently skipped) - validate underlying behavior
- [x] Refactor two xfail tests to use context manager with expected error
- [x] Add `pytest-order` dependency before we need it

After rebasing with staging, 4 other tests failed - this uncovered a few areas we needed to adjust either the test or add checks in the code.

- check if an item has `enable_handling_unit` checked (as well as `is_stock_item`)
- check if a BOM scrap item has 'create a handling unit' checked

Additionally, there was a timing issue on the Stock Entry doc event in hooks. The `validate_items_with_handling_unit` in `validate` was throwing errors for missing handlings units when they weren't created yet (that step is done in `before_submit` via `generate_handling_units`). I moved the validate function to run AFTER the handling units are generated, now both in the `before_submit` hook

## Net Quantity

For net quantity, the underlying Stock Ledger entries use the `transfer_qty` field (from the Stock Entry Detail item row) when updating the handling unit's `stock_qty`. This field gets set and updated in the UI when the `qty` field changes, so in UI tests to transfer part of an HU, the stock ledger correctly shows net totals. Good news, most of the issue here was tied to fields not being set programmatically in the tests (it's done on a field change in the JS, not server-side), so the main "fix" was to explicitly set a few more fields in the tests.

The failing test had the following issues:

- the repack test was running first, which changed the Parchment Paper HU. The net qty test then would grab the 'old' HU with `stock_qty` of 0 and show a negative balance. Separately, the overconsumption code wasn't throwing an error when this happened because it was looking for the `actual_qty` field, which was zero (the field doesn't get set programmatically in the tests or on save), so there's no overconsumption when zero units are removed from the HU. I created a 'clean' Material Receipt for Parchment Paper and used its HU for the test to avoid the issue
- The `transfer_qty` field (what the stock ledger entries use to adjust the HU's quantity) also wasn't being set on save/submit programmatically in the test, so the code was 'netting out' zero from the HU. This caused the Assertion Error when the test checks if the HU qty == 95 because the math did 100 - 0 instead of 100 - 5. The test now explicitly sets the `transfer_qty` field, so the calcs have the right value to work with

## Overconsumption Updates (FOR DISCUSSION):

When the overconsumption code was turned on (uncommented in hooks.py, and tests not skipped), `test_handling_units_overconsumption_in_material_transfer_stock_entry` failed because it didn't raise the known error. The first issue was that the `actual_qty` field wasn't being set in the test, which is what the overconsumption check uses to compare to the HU `stock_qty`. The second issue was that the calc itself didn't catch when the test tried to use 8 units from a HU of 5 units.

Some changes:

- In general, the overconsumption check wasn't catching things because of behavior associated with the `actual_qty` field it was using to compare against the HU's quantity. The `actual_qty` field in a Stock Entry Detail item row gets set when an item is added/source WH is set, but doesn't change when the `qty` field changes in the UI or when I hit Save. So if I scan an HU, then manually adjust the `qty`, the `actual_qty` field doesn't update (see screen shot). To avoid mismatched quantity issues and to conform the overconsumption code with how the Stock Ledger Entries calculate net quantity, I changed the calculation to use the `transfer_qty` field
- I adjusted the calculation so the code throws an error when the Stock Entry tries to consume/use/transfer 8 units of a HU with 5 units in it. This change made the "#incoming" code block math the same as the "#transfer" one, so I combined them
- For the "#outgoing" code block (when there's only a `t_warehouse`, like for finished goods or a Material Receipt), I had a little trouble writing a test because of the sequence of events in that scenario. HUs are generated for those rows in `before_submit`, so it's tricky to change the qty after that happens to trigger an error in the test. I was wondering why the math was different in this case - maybe this is too simplistic, but when I think of how to define overconsumption, I figure if the quantity we're receiving/issuing/transfering/etc (row qty) less the HU qty is more than precision threshold, then it's overconsumption / throw error


Screen shot shows the values for the key fields we're using - when I changed the `qty` field and re-ran the console, it shows the `qty` and `transfer_qty` fields update, the `actual_qty` field remains the value that was set once the WH was added for the item. I also checked after adding a HU and after hitting save - same result.

<img width="996" alt="Screenshot 2024-05-12 at 3 14 09 PM" src="https://github.com/agritheory/beam/assets/9591826/6b69acf7-f226-4973-8f03-3cd6c707c33b">

