### PR TITLE
feat: implement pagination for demand

### DIFF
--- a/beam/www/beam/pages/Demand.vue
+++ b/beam/www/beam/pages/Demand.vue
@@ -7,12 +7,14 @@
 			<RouterLink :to="{ name: 'home' }">Home</RouterLink>
 		</template>
 	</Navbar>
+
 	<ListView :items="transfer" />
 </template>
 
 <script setup lang="ts">
 import { Navbar } from '@stonecrop/beam'
-import { onMounted, ref } from 'vue'
+import { useInfiniteScroll } from '@vueuse/core'
+import { ref } from 'vue'
 
 import { useDataStore } from '@/store'
 import type { ListViewItem } from '@/types'
@@ -21,20 +23,32 @@ declare const frappe: any
 
 const store = useDataStore()
 const transfer = ref<Partial<ListViewItem>[]>([])
+const canLoadMore = ref(true)
+const page = ref(1)
 
-onMounted(async () => {
-	const { data } = await store.getDemand({ order_by: 'creation asc' })
+useInfiniteScroll(
+	window,
+	async () => {
+		const { data } = await store.getDemand({ order_by: 'creation asc', page: page.value })
+		if (data.length === 0) {
+			canLoadMore.value = false
+			return
+		}
 
-	// TODO: move this to the server
-	data.forEach(row => {
-		row.count = { count: row.allocated_qty, of: `${row.total_required_qty} ${row.stock_uom}` }
-		row.label = `${row.item_code} from ${row.warehouse}`
-		row.linkComponent = 'ListAnchor'
-		row.description = row.parent
-		row.route = `#/${frappe.scrub(row.doctype)}/${row.parent}`
-		transfer.value.push(row)
-	})
-})
+		// TODO: move this to the server
+		data.forEach(row => {
+			row.count = { count: row.allocated_qty, of: `${row.total_required_qty} ${row.stock_uom}` }
+			row.label = `${row.item_code} from ${row.warehouse}`
+			row.linkComponent = 'ListAnchor'
+			row.description = row.parent
+			row.route = `#/${frappe.scrub(row.doctype)}/${row.parent}`
+			transfer.value.push(row)
+		})
+
+		page.value++
+	},
+	{ canLoadMore: () => canLoadMore.value }
+)
 
 // const handlePrimaryAction = () => {}
 </script>

--- a/beam/www/beam/pages/JobCard.vue
+++ b/beam/www/beam/pages/JobCard.vue
@@ -1,26 +1,19 @@
 <template>
-	<li v-for="operation in workOrder.operations">
+	<li v-for="operation in store.form.operations">
 		<router-link :to="{ name: 'operation', params: { orderId: route.params.orderId, id: operation.name } }">
 			<span>{{ operation.operation }}</span>
-			<span class="right-align"> ({{ operation.completed_qty }} / {{ workOrder.qty }})</span>
+			<span class="right-align"> ({{ operation.completed_qty }} / {{ store.form.qty }})</span>
 		</router-link>
 	</li>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { useDataStore } from '@/store'
-import type { WorkOrder } from '@/types'
 
 const route = useRoute()
 const store = useDataStore()
-const workOrder = ref<Partial<WorkOrder>>({})
-
-onMounted(async () => {
-	workOrder.value = await store.getOne<WorkOrder>('Work Order', route.params.orderId.toString())
-})
 </script>
 
 <style scoped>

--- a/beam/www/beam/pages/Operation.vue
+++ b/beam/www/beam/pages/Operation.vue
@@ -21,7 +21,6 @@ import type { JobCard, WorkOrder, WorkOrderOperation } from '@/types'
 const route = useRoute()
 const store = useDataStore()
 
-const workOrder = ref<Partial<WorkOrder>>({})
 const operation = ref<Partial<WorkOrderOperation>>({})
 const jobCard = ref<Partial<JobCard>>({})
 
@@ -36,8 +35,8 @@ const elapsedTime = computed(() => {
 })
 
 onMounted(async () => {
-	workOrder.value = await store.getOne<WorkOrder>('Work Order', route.params.orderId.toString())
-	operation.value = workOrder.value.operations.find(operation => operation.name === route.params.id) || {}
+	const workOrder = store.form as Partial<WorkOrder>
+	operation.value = workOrder.operations.find(operation => operation.name === route.params.id) || {}
 
 	const jobList = await store.getAll<JobCard[]>('Job Card', {
 		filters: JSON.stringify([['operation_id', '=', route.params.id]]),

--- a/beam/www/beam/pages/Ship.vue
+++ b/beam/www/beam/pages/Ship.vue
@@ -31,7 +31,7 @@ onMounted(async () => {
 	})
 })
 
-// const handlePrimaryAction = () => {}
+const handlePrimaryAction = () => {}
 </script>
 
 <style>

--- a/beam/www/beam/store.ts
+++ b/beam/www/beam/store.ts
@@ -19,6 +19,7 @@ import type {
 declare const frappe: any
 
 export const useDataStore = defineStore('data', () => {
+	const recordsPerPage = 20
 	const route = useRoute()
 
 	const config = ref<ScanConfig>({})
@@ -111,7 +112,13 @@ export const useDataStore = defineStore('data', () => {
 		return data
 	}
 
-	const getAll = async <T>(doctype: string, params?: Record<string, any>) => {
+	const getAll = async <T>(doctype: string, params?: Record<string, any>, page?: number) => {
+		if (page) {
+			const start = (page - 1) * recordsPerPage
+			const end = start + recordsPerPage
+			params = { ...params, limit_start: start, limit_page_length: end }
+		}
+
 		const url = `/api/resource/${doctype}`
 		const response = await get(url, params)
 		const { data }: { data: T } = await response.json()
@@ -120,25 +127,10 @@ export const useDataStore = defineStore('data', () => {
 
 	const getDemand = async (params?: Record<string, any>) => {
 		// automatically fetch all pages of demand data based on parameters
-		const demandUrl = '/api/method/beam.beam.demand.demand.get_demand'
-		const url = formatUrl(demandUrl, params)
-		return await getPaginated(url)
-	}
-
-	// ref: https://observablehq.com/@xari/paginated_fetch
-	const getPaginated = async (url: string, page: number = 1, previousResponse: any[] = []) => {
-		const pageFragment = `${url}&page=${page}`
-		const formattedUrl = new URL(pageFragment, window.location.origin)
-		const response = await fetch(formattedUrl)
-		const data = await response.json()
-
-		const combinedResponse = [...previousResponse, ...data.message]
-		if (data.message.length !== 0) {
-			page++
-			return await getPaginated(url, page, combinedResponse)
-		}
-
-		return { data: combinedResponse }
+		const url = '/api/method/beam.beam.demand.demand.get_demand'
+		const response = await get(url, params)
+		const { message } = await response.json()
+		return { data: message }
 	}
 
 	const scan = async (barcode: string, qty: number): Promise<(FormContext | ListContext)[]> => {
@@ -227,7 +219,6 @@ export const useDataStore = defineStore('data', () => {
 		getDemand,
 		getMappedStockEntry,
 		getOne,
-		getPaginated,
 		scan,
 	}
 })

--- a/beam/www/beam/vite.config.ts
+++ b/beam/www/beam/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig({
 		lib: {
 			entry: resolve(__dirname, 'index.ts'),
 			name: 'beam',
-			formats: ['es'], // only create module output for Frappe
-			fileName: format => `index.js`, // creates module only output
+			formats: ['umd'], // only create module output for Frappe
+			fileName: () => 'index.js',
 		},
 		rollupOptions: {
 			output: {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@stonecrop/beam": "latest",
 		"@vitejs/plugin-vue": "^5.1.4",
+		"@vueuse/core": "^11.1.0",
 		"onscan.js": "^1.5.2",
 		"pinia": "^2.2.2",
 		"vite": "^5.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,6 +253,11 @@
   dependencies:
     undici-types "~6.19.2"
 
+"@types/web-bluetooth@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
+  integrity sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==
+
 "@vitejs/plugin-vue@^5.1.4":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-5.1.4.tgz#72b8b705cfce36b00b59af196195146e356500c4"
@@ -342,6 +347,28 @@
   version "3.5.6"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.6.tgz#602b3c2dccfe612f9e2e52e861dd7db340961a4f"
   integrity sha512-eidH0HInnL39z6wAt6SFIwBrvGOpDWsDxlw3rCgo1B+CQ1781WzQUSU3YjxgdkcJo9Q8S6LmXTkvI+cLHGkQfA==
+
+"@vueuse/core@^11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-11.1.0.tgz#a104f33c899a15f3b28d3eb7b20738501a3a5035"
+  integrity sha512-P6dk79QYA6sKQnghrUz/1tHi0n9mrb/iO1WTMk/ElLmTyNqgDeSZ3wcDf6fRBGzRJbeG1dxzEOvLENMjr+E3fg==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.20"
+    "@vueuse/metadata" "11.1.0"
+    "@vueuse/shared" "11.1.0"
+    vue-demi ">=0.14.10"
+
+"@vueuse/metadata@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-11.1.0.tgz#ad367d2a51d985129724425923b3cf95f0faf27b"
+  integrity sha512-l9Q502TBTaPYGanl1G+hPgd3QX5s4CGnpXriVBR5fEZ/goI6fvDaVmIl3Td8oKFurOxTmbXvBPSsgrd6eu6HYg==
+
+"@vueuse/shared@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-11.1.0.tgz#3bfc3aa555c2a456c21945ec7f127d71938d12e8"
+  integrity sha512-YUtIpY122q7osj+zsNMFAfMTubGz0sn5QzE5gPzAIiCmtt2ha3uQUY1+JPyL4gRCTsLPX82Y9brNbo/aqlA91w==
+  dependencies:
+    vue-demi ">=0.14.10"
 
 csstype@^3.1.3:
   version "3.1.3"
@@ -525,7 +552,7 @@ vite@^5.4.6:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vue-demi@^0.14.10:
+vue-demi@>=0.14.10, vue-demi@^0.14.10:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
   integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==


### PR DESCRIPTION
Closes #160 

---

**Changes:**
- Apply pagination to the Demand component using VueUse's [`useInfiniteScroll`](https://vueuse.org/core/useInfiniteScroll/#useinfinitescroll) composable
- Cleanup data initialization in some components via the Pinia data store
- Add arguments to existing `getAll` method for paginating Frappe's resource API responses
- Change Vite's build output format from ES to UMD to mitigate global namespace clash issues (also creates a smaller output but a larger sourcemap)