### PR TITLE
fix: delete redirect-to

### DIFF
--- a/beam/beam/boot.py
+++ b/beam/beam/boot.py
@@ -26,6 +26,6 @@ def redirect_to_beam():
 	]
 
 	if "BEAM Mobile User" in user_roles or any(agent in user_agent for agent in mobile_keywords):
-		frappe.local.response["home_page"] = "/beam/"
+		frappe.local.response["home_page"] = "/beam#/"
 		# frappe.local.response["type"] = "redirect"
 		# frappe.local.response["location"] = f"{frappe.utils.get_url()}/beam/"

--- a/beam/public/js/beam-web.bundle.js
+++ b/beam/public/js/beam-web.bundle.js
@@ -14,15 +14,10 @@ if (window.location.pathname === '/beam') {
 // remove redirect-to query parameter on login page for mobile users
 document.addEventListener('DOMContentLoaded', function () {
 	if (window.location.pathname === '/login') {
-		function isMobileDevice() {
-			return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
-		}
-		if (isMobileDevice()) {
-			const url = new URL(window.location.href)
-			if (url.searchParams.has('redirect-to')) {
-				url.searchParams.delete('redirect-to')
-				window.history.replaceState({}, document.title, url.toString())
-			}
+		const url = new URL(window.location.href)
+		if (url.searchParams.has('redirect-to')) {
+			url.searchParams.delete('redirect-to')
+			window.history.replaceState({}, document.title, url.toString())
 		}
 	}
 })


### PR DESCRIPTION
Remove the isMobileDevice function from the JavaScript code to consistently clear the redirect-to parameter. This ensures that BEAM Mobile Users are always redirected to /beam, mobile or desktop version. For users without this role, logging in from a mobile device will redirect them to /beam, logging in from a desktop will redirect them to /app/home (the homepage).

Plus in boot.py change home page "/beam/" to "beam#" to fix styles issues

![Captura de pantalla 2024-11-22 a la(s) 2 52 50 p  m](https://github.com/user-attachments/assets/e95459ab-d994-4f00-af1f-b7da9e6e919c)

![Captura de pantalla 2024-11-22 a la(s) 2 53 52 p  m](https://github.com/user-attachments/assets/1f12ef77-47b2-461b-b09c-140d7c51ad89)

