### PR TITLE
fix: remove assumption about demand route in beam settings

### DIFF
--- a/beam/beam/doctype/beam_settings/beam_settings.py
+++ b/beam/beam/doctype/beam_settings/beam_settings.py
@@ -32,29 +32,6 @@ class BEAMSettings(Document):
 		self.set_onload("components", hooks.components)
 		self.set_onload("routes", hooks.routes)
 
-	def validate(self):
-		# adding a label check since multiple paths can use the Demand component
-		existing_demand_route = [
-			route for route in self.routes if route.label == "Demand" and route.component == "Demand"
-		]
-
-		if self.enable_demand:
-			# add demand route into mobile list
-			if not existing_demand_route:
-				self.append(
-					"routes",
-					{
-						"component": "Demand",
-						"dt": "Stock Entry",
-						"label": "Demand",
-						"route": "#/demand",
-					},
-				)
-		else:
-			# remove demand route from mobile list
-			if existing_demand_route:
-				self.remove(existing_demand_route[0])
-
 	def get_beam_mobile_home_for_user(self, user):
 		allowed_routes = []
 		for row in self.routes:


### PR DESCRIPTION
The desire to have the demand list view in mobile and enabling calculation of demand are related but may be distinct requirements. 