### PR TITLE
fix: added remaining_time_in_mins in job card

### DIFF
--- a/beam/tests/setup.py
+++ b/beam/tests/setup.py
@@ -706,6 +706,7 @@ def create_production_plan(settings, prod_plan_from_doc):
 					"from_time": start_time,
 					"to_time": start_time + datetime.timedelta(minutes=time_in_mins),
 					"time_in_mins": time_in_mins,
+					"remaining_time_in_mins": time_in_mins,
 				},
 			)
 			job_card.save()


### PR DESCRIPTION
I added `remaining_time_in_mins` to enable setup execution before the test.

This change is based on the [merge](https://github.com/frappe/erpnext/compare/v15.48.1...v15.48.2)
