### PR TITLE
feat: repack page

### DIFF
--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -174,6 +174,8 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 	if barcode_doc.doc.doctype == "Handling Unit":
 		hu_details = get_handling_unit(barcode_doc.doc.name, context.frm)
 		if context.frm == "Stock Entry":
+			if not context.doc:
+				context.doc = { "doctype": "Stock Entry" }
 			target = get_stock_entry_item_details(context.doc, hu_details.item_code)
 			target.warehouse = hu_details.warehouse
 		elif context.frm in ("Putaway Rule", "Warranty Claim", "Item Price", "Quality Inspection"):

--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -175,7 +175,7 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 		hu_details = get_handling_unit(barcode_doc.doc.name, context.frm)
 		if context.frm == "Stock Entry":
 			if not context.doc:
-				context.doc = { "doctype": "Stock Entry" }
+				context.doc = {"doctype": "Stock Entry"}
 			target = get_stock_entry_item_details(context.doc, hu_details.item_code)
 			target.warehouse = hu_details.warehouse
 		elif context.frm in ("Putaway Rule", "Warranty Claim", "Item Price", "Quality Inspection"):

--- a/beam/hooks.py
+++ b/beam/hooks.py
@@ -625,7 +625,7 @@ beam_mobile = {
 			"path": "/repack",
 			"name": "repack",
 			"component": "Repack",
-			"meta": {"requiresAuth": True, "doctype": "Stock Entry", "view": "list"},
+			"meta": {"requiresAuth": True, "doctype": "Stock Entry", "view": "form"},
 		},
 		{
 			"path": "/:catchAll(.*)*",

--- a/beam/hooks.py
+++ b/beam/hooks.py
@@ -625,7 +625,7 @@ beam_mobile = {
 			"path": "/repack",
 			"name": "repack",
 			"component": "Repack",
-			"meta": {"requiresAuth": True, "doctype": "Stock Entry", "view": "form"},
+			"meta": {"requiresAuth": True, "doctype": "Stock Entry", "view": "list"},
 		},
 		{
 			"path": "/:catchAll(.*)*",

--- a/beam/www/beam/pages/Move.vue
+++ b/beam/www/beam/pages/Move.vue
@@ -43,7 +43,7 @@ const store = useBeamStore()
 const items = ref<ListViewItem[]>([])
 const stockEntry = computed(
 	(): StockEntry =>
-		(store.cache.mappers[''] as StockEntry) || {
+		(store.cache.mappers['move'] as StockEntry) || {
 			name: '',
 			stock_entry_type: 'Material Transfer',
 			items: [],
@@ -57,9 +57,7 @@ const warehouseList = ref<string[]>([])
 
 onMounted(async () => {
 	store.form as Partial<StockEntry>
-	store.$patch(state => {
-		state.cache.mappers[''] = stockEntry.value
-	})
+	store.$patch(state => state.cache.mappers['move'] = stockEntry.value)
 	await loadWarehouses()
 })
 
@@ -72,7 +70,7 @@ const loadWarehouses = async () => {
 
 const clearField = (field: 'from_warehouse' | 'to_warehouse') => {
 	store.$patch(state => {
-		const mapper = state.cache.mappers['']
+		const mapper = state.cache.mappers['move']
 		if (mapper) mapper[field] = ''
 	})
 }
@@ -128,7 +126,7 @@ const move = async () => {
 	const res = await store.submit<StockEntry>('Stock Entry', stockEntry.value.name)
 	if (res?.data)
 		store.$patch(state => {
-			state.cache.mappers[''] = {
+			state.cache.mappers['move'] = {
 				name: '',
 				stock_entry_type: 'Material Transfer',
 				items: [],
@@ -158,7 +156,7 @@ const controlButtons = computed((): ControlButton[] => {
 })
 
 watch(
-	() => store.cache.mappers['']?.items,
+	() => store.cache.mappers['move']?.items,
 	newItems => {
 		items.value = (newItems || []).map(s => ({
 			...s,

--- a/beam/www/beam/pages/Move.vue
+++ b/beam/www/beam/pages/Move.vue
@@ -58,15 +58,8 @@ const warehouseList = ref<string[]>([])
 onMounted(async () => {
 	store.form as Partial<StockEntry>
 	store.$patch(state => (state.cache.mappers['move'] = stockEntry.value))
-	await loadWarehouses()
+	warehouseList.value = store.warehouseList.filter(w => !w.is_group).map(w => w.name)
 })
-
-const loadWarehouses = async () => {
-	const warehouses = await store.getAll<Warehouse[]>('Warehouse', {
-		filters: JSON.stringify([['is_group', '!=', '1']]),
-	})
-	warehouseList.value = warehouses.map(warehouse => warehouse.name)
-}
 
 const clearField = (field: 'from_warehouse' | 'to_warehouse') => {
 	store.$patch(state => {

--- a/beam/www/beam/pages/Move.vue
+++ b/beam/www/beam/pages/Move.vue
@@ -57,7 +57,7 @@ const warehouseList = ref<string[]>([])
 
 onMounted(async () => {
 	store.form as Partial<StockEntry>
-	store.$patch(state => state.cache.mappers['move'] = stockEntry.value)
+	store.$patch(state => (state.cache.mappers['move'] = stockEntry.value))
 	await loadWarehouses()
 })
 

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -12,7 +12,11 @@
 		<div class="container">
 			<template v-if="itemList">
 				<div class="dd-container">
-					<ADropdown label="Item to Repack" :items="itemList" v-model="currentItem.item_code" :isAsync="true"
+					<ADropdown
+						label="Item to Repack"
+						:items="itemList"
+						v-model="currentItem.item_code"
+						:isAsync="true"
 						:filterFunction="loadItems" />
 					<BeamBtn class="clear-button" @click="clearCurrentItem('item_code')"> X </BeamBtn>
 				</div>
@@ -45,12 +49,13 @@
 </template>
 
 <script setup lang="ts">
+import type { ListViewItem } from '@stonecrop/beam'
 import { ref, computed, onMounted, watch } from 'vue'
-import { useBeamStore } from '@/stores/beam'
-import { useBeamToast } from '@/utils/toast.js'
-import { ListViewItem } from '@stonecrop/beam'
+
 import ControlButtons from '@/components/ControlButtons.vue'
+import { useBeamStore } from '@/stores/beam'
 import type { ControlButton, DocActionResponse, StockEntry } from '@/types'
+import { useBeamToast } from '@/utils/toast.js'
 
 const toast = useBeamToast()
 const store = useBeamStore()
@@ -58,8 +63,8 @@ const currentItem = ref({ item_code: '', qty: 0, bom: '' })
 const items = ref([])
 const componentKey = ref(0)
 const stockEntry = computed(
-	(): StockEntry =>
-		(store.cache.mappers['repack'] as StockEntry) || {
+	() =>
+		store.cache.mappers.repack || {
 			name: '',
 			stock_entry_type: 'Repack',
 			items: [],
@@ -73,19 +78,18 @@ const bomList = ref<string[]>([])
 const warehouseList = ref<string[]>([])
 
 onMounted(async () => {
-	store.$patch(state => state.cache.mappers['repack'] = stockEntry.value)
+	store.$patch(state => (state.cache.mappers.repack = stockEntry.value))
 	await loadBOMs()
 	await loadWarehouses()
 })
 
 const loadItems = async (search: string) => {
 	if (!search) return []
-	const itemsData = await store.getAll<{ name: string }[]>('Item', {
+	const items = await store.getAll<{ name: string }[]>('Item', {
 		filters: JSON.stringify([['item_code', 'like', `${search}%`]]),
 	})
-	const itemsMapped = itemsData.map(item => item.name)
-	itemList.value = itemsMapped
-	return itemsMapped.filter(item => item.toLocaleLowerCase().startsWith(search.toLocaleLowerCase()))
+	itemList.value = items.map(item => item.name)
+	return itemList.value.filter(item => item.toLocaleLowerCase().startsWith(search.toLocaleLowerCase()))
 }
 
 const loadBOMs = async () => {
@@ -100,13 +104,12 @@ const loadWarehouses = async () => {
 	warehouseList.value = warehouses.map(warehouse => warehouse.name)
 }
 
-const clearField = (field: 'from_warehouse' | 'to_warehouse') => store.$patch(state => state.cache.mappers.repack[field] = '')
-
-const clearCurrentItem = (field: 'item_code' | 'bom') => currentItem.value[field] = ''
-
-const substractCurrentItem = () => currentItem.value.qty > 0 ? currentItem.value.qty-- : 0
+const clearField = (field: 'from_warehouse' | 'to_warehouse') =>
+	store.$patch(state => (state.cache.mappers.repack[field] = ''))
 
 const addCurrentItem = () => currentItem.value.qty++
+const substractCurrentItem = () => (currentItem.value.qty > 0 ? currentItem.value.qty-- : 0)
+const clearCurrentItem = (field: 'item_code' | 'bom') => (currentItem.value[field] = '')
 
 const create = async () => {
 	const body: StockEntry = {
@@ -122,7 +125,7 @@ const create = async () => {
 		res = await store.insert<StockEntry>('Stock Entry', body)
 	}
 	const { data, response } = res
-	if (data?.name) store.$patch(state => state.cache.mappers.repack.name = data.name)
+	if (data?.name) store.$patch(state => (state.cache.mappers.repack.name = data.name))
 
 	return { data, response }
 }
@@ -131,7 +134,7 @@ const repack = async () => {
 	const res = await store.submit<StockEntry>('Stock Entry', stockEntry.value.name || '')
 	if (res?.data) {
 		store.$patch(state => {
-			state.cache.mappers['repack'] = {
+			state.cache.mappers.repack = {
 				name: '',
 				stock_entry_type: 'Repack',
 				items: [],
@@ -156,17 +159,17 @@ const addItem = () => {
 		toast.error('Please select only source or target warehouse')
 		return
 	}
-	items.value.push(
-		{
-			label: currentItem.value.item_code,
-			count: { count: currentItem.value.qty },
-			description: stockEntry.value.from_warehouse ? `From ${stockEntry.value.from_warehouse}` : `To ${stockEntry.value.to_warehouse}`,
-			item_code: currentItem.value.item_code,
-			qty: currentItem.value.qty,
-			s_warehouse: stockEntry.value.from_warehouse,
-			t_warehouse: stockEntry.value.to_warehouse,
-		}
-	)
+	items.value.push({
+		label: currentItem.value.item_code,
+		count: { count: currentItem.value.qty },
+		description: stockEntry.value.from_warehouse
+			? `From ${stockEntry.value.from_warehouse}`
+			: `To ${stockEntry.value.to_warehouse}`,
+		item_code: currentItem.value.item_code,
+		qty: currentItem.value.qty,
+		s_warehouse: stockEntry.value.from_warehouse,
+		t_warehouse: stockEntry.value.to_warehouse,
+	})
 
 	currentItem.value = { item_code: '', qty: 0, bom: '' }
 	clearField('from_warehouse')
@@ -176,7 +179,7 @@ const addItem = () => {
 const clearItem = () => {
 	currentItem.value.bom = ''
 	items.value = []
-	store.$patch(state => state.cache.mappers.repack.items = [])
+	store.$patch(state => (state.cache.mappers.repack.items = []))
 }
 
 const controlButtons = computed((): ControlButton[] => {
@@ -184,6 +187,7 @@ const controlButtons = computed((): ControlButton[] => {
 		{ label: 'CLEAN', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: clearItem },
 		{ label: 'ADD', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: addItem },
 	]
+
 	if (items.value.length === 0) return buttons
 	return [
 		{
@@ -192,24 +196,24 @@ const controlButtons = computed((): ControlButton[] => {
 			hidden: !stockEntry.value.name,
 			color: {
 				background: '#4791FF',
-				text: 'var(--sc-btn-color)'
+				text: 'var(--sc-btn-color)',
 			},
-			action: repack
+			action: repack,
 		},
 		{
 			label: 'SAVE',
 			color: {
 				background: '#4791FF',
-				text: 'var(--sc-btn-color)'
+				text: 'var(--sc-btn-color)',
 			},
-			action: create
+			action: create,
 		},
 		...buttons,
 	]
 })
 
 watch(
-	() => store.cache.mappers['repack']?.items,
+	() => store.cache.mappers.repack?.items,
 	(newItems: ListViewItem[]) => {
 		// Update items list on Scan
 		if (!newItems) return
@@ -228,10 +232,10 @@ watch(
 
 watch(
 	() => currentItem.value.bom,
-	async (bom) => {
+	async bom => {
 		// Update items list on BOM selection
 		if (!currentItem.value.bom) return
-		const listBom = await store.getStockEntryItems(bom);
+		const listBom = await store.getStockEntryItems(bom)
 		items.value = listBom.map(bomItem => ({
 			label: bomItem.description,
 			count: { count: bomItem.qty },
@@ -280,7 +284,7 @@ watch(
 	font-size: 150% !important;
 	outline: 1px solid transparent !important;
 	border: 1px solid var(--sc-input-border-color) !important;
-	border-radius: .25rem !important;
+	border-radius: 0.25rem !important;
 	width: 90% !important;
 }
 

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -76,7 +76,7 @@ const warehouseList = ref<string[]>([])
 onMounted(async () => {
 	store.$patch(state => (state.cache.mappers.repack = stockEntry.value))
 	await loadBOMs()
-	await loadWarehouses()
+	warehouseList.value = store.warehouseList.filter(w => !w.is_group).map(w => w.name)
 })
 
 const loadItems = async (search: string) => {
@@ -91,13 +91,6 @@ const loadItems = async (search: string) => {
 const loadBOMs = async () => {
 	const boms = await store.getAll<{ name: string }[]>('BOM')
 	bomList.value = boms.map(bom => bom.name)
-}
-
-const loadWarehouses = async () => {
-	const warehouses = await store.getAll<{ name: string }[]>('Warehouse', {
-		filters: JSON.stringify([['is_group', '!=', '1']]),
-	})
-	warehouseList.value = warehouses.map(warehouse => warehouse.name)
 }
 
 const clearField = (field: 'from_warehouse' | 'to_warehouse') =>

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -37,7 +37,7 @@
 		</div>
 	</div>
 
-	<ListView v-if="items.length > 0" :items="items" :key="componentKey" />
+	<ListView v-if="items.length > 0" :items="items" :key="componentKey" class="max-h-300" />
 	<div class="begin" v-else>
 		<span>Scan Items, Select Warehouses, and Set Qty to Begin</span>
 	</div>
@@ -223,20 +223,48 @@ const controlButtons = computed((): ControlButton[] => {
 	]
 })
 
+function flattenItems(items: ListViewItem[]): ListViewItem[] {
+	const mergedMap = new Map<string, ListViewItem>();
+
+	items.forEach(item => {
+		const existing = mergedMap.get(item.item_code);
+		if (existing) {
+			mergedMap.set(
+				item.item_code,
+				{
+					item_code: item.item_code,
+					qty: item.transfer_qty || item.qty || 0,
+					from_warehouse: item.s_warehouse || ''
+				}
+			);
+		} else {
+			mergedMap.set(item.item_code, { ...item });
+		}
+	});
+
+	return Array.from(mergedMap.values());
+}
+
 watch(
 	() => store.cache.mappers.repack?.items,
 	(newItems: ListViewItem[]) => {
 		// Update items list on Scan
 		if (!newItems) return
 		if (currentItem.value.bom) return
-
-		const newItem = newItems[newItems.length - 1]
+		const flattened = flattenItems(newItems);
+		const newItem = flattened[flattened.length - 1]
 		if (!newItem) return
-		if (items.value.some(i => i.label === newItem.item_code)) return
-		itemList.value = [newItem.item_code]
-		const qty = newItem.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
+		const itemExists = items.value.some(i => i.label === newItem.item_code)
+		// if (itemExists) {
+		// 	toast.error(`${newItem.item_code} already added`)
+		// 	return
+		// }
+		itemList.value = [newItem.item_code] // ADropdown needs the list to keep the selected item
+		const qty = newItem.item_code === currentItem.value.item_code ? currentItem.value.qty + newItem.qty : newItem.qty
 
 		currentItem.value = { ...newItem, qty }
+		if (newItem.from_warehouse) stockEntry.value.from_warehouse = newItem.from_warehouse
+		store.$patch(state => (state.cache.mappers.repack.items = []))
 	},
 	{ immediate: true, deep: true }
 )
@@ -274,6 +302,12 @@ watch(
 
 .repack .input-wrapper label {
 	margin: calc(-2.5rem - calc(2.15rem / 2)) 0 0 1ch !important;
+}
+
+.max-h-300 {
+	max-height: 300px;
+	overflow: scroll;
+	padding-bottom: 0px !important;
 }
 
 .container {

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -12,25 +12,18 @@
 		<div class="container">
 			<template v-if="itemList">
 				<div class="dd-container">
-					<ADropdown
-						label="Item to Repack"
-						:items="itemList"
-						v-model="currentItem.item_code"
-						:isAsync="true"
-						:filterFunction="loadItems"
-					/>
-					<BeamBtn class="clear-button" @click="clearCurrentItem"> X </BeamBtn>
+					<ADropdown label="Item to Repack" :items="itemList" v-model="currentItem.item_code" :isAsync="true"
+						:filterFunction="loadItems" />
+					<BeamBtn class="clear-button" @click="clearCurrentItem('item_code')"> X </BeamBtn>
 				</div>
 				<div class="dd-container wrapper">
 					<BeamBtn class="clear-button" @click="substractCurrentItem"> - </BeamBtn>
-					<!-- <div class="wrapper">
-						<input label="Qty" type="number" v-model="currentItem.qty" />
-					</div> -->
 					<ANumericInput label="Quantity" v-model="currentItem.qty" />
 					<BeamBtn class="clear-button" @click="addCurrentItem"> + </BeamBtn>
 				</div>
 				<div class="dd-container">
 					<ADropdown label="BOM (Optional)" :items="bomList" v-model="currentItem.bom" />
+					<BeamBtn class="clear-button" @click="clearCurrentItem('bom')"> X </BeamBtn>
 				</div>
 			</template>
 			<div class="dd-container">
@@ -44,8 +37,8 @@
 		</div>
 	</div>
 
-	<ListView :items="items" :key="componentKey" @update="update" />
-	<div class="begin" v-if="items.length == 0">
+	<ListView v-if="items.length > 0" :items="items" :key="componentKey" />
+	<div class="begin" v-else>
 		<span>Scan Items, Select Warehouses, and Set Qty to Begin</span>
 	</div>
 
@@ -55,13 +48,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { useBeamStore } from '@/stores/beam'
-import ControlButtons from '@/components/ControlButtons.vue'
+import { useHttpStore } from '@/stores/http.js'
+import { useBeamToast } from '@/utils/toast.js'
 import { ListViewItem } from '@stonecrop/beam'
-import type { ControlButton, StockEntry } from '@/types'
+import ControlButtons from '@/components/ControlButtons.vue'
+import type { ControlButton, DocActionResponse, StockEntry, BomItem } from '@/types'
 
+const httpStore = useHttpStore()
+const toast = useBeamToast()
 const store = useBeamStore()
-const currentItem = ref<ListViewItem>({ item_code: '', qty: 0, bom: '' })
-const items = ref<ListViewItem[]>([])
+const currentItem = ref({ item_code: '', qty: 0, bom: '' })
+const items = ref([])
 const componentKey = ref(0)
 const stockEntry = computed(
 	(): StockEntry =>
@@ -99,6 +96,29 @@ const loadBOMs = async () => {
 	bomList.value = boms.map(bom => bom.name)
 }
 
+const getStockEntryItems = async (bomName: string, company = "Ambrosia Pie Company", qty = 1, purpose = "Manufacture") => {
+	try {
+		const response = await httpStore.get("/api/method/erpnext.manufacturing.doctype.bom.bom.get_bom_items", {
+			bom: bomName,
+			company,
+			fetch_exploded: 1,
+			qty,
+			purpose,
+		})
+		const { message }: { message: BomItem[] } = await response.json()
+
+		if (!message) {
+			console.error("La respuesta no contiene 'message'", response)
+			return []
+		}
+
+		return message
+	} catch (error) {
+		console.error("Error en getStockEntryItems:", error)
+		return []
+	}
+}
+
 const loadWarehouses = async () => {
 	const warehouses = await store.getAll<{ name: string }[]>('Warehouse', {
 		filters: JSON.stringify([['is_group', '!=', '1']]),
@@ -108,28 +128,33 @@ const loadWarehouses = async () => {
 
 const clearField = (field: 'from_warehouse' | 'to_warehouse') => stockEntry.value[field] = ''
 
-const clearCurrentItem = () => currentItem.value = { item_code: '', qty: 0, bom: '' }
-
-const addCurrentItem = () => currentItem.value.qty++
+const clearCurrentItem = (field: 'item_code' | 'bom') => currentItem.value[field] = ''
 
 const substractCurrentItem = () => currentItem.value.qty--
 
-const update = () => {
-	// TODO
-}
+const addCurrentItem = () => currentItem.value.qty++
 
 const create = async () => {
 	const body: StockEntry = {
 		stock_entry_type: 'Repack',
-		items: stockEntry.value.items || [],
-		from_warehouse: stockEntry.value.from_warehouse,
-		to_warehouse: stockEntry.value.to_warehouse,
+		items: stockEntry.value.items.map(i => ({
+			...i,
+			s_warehouse: stockEntry.value.from_warehouse,
+			t_warehouse: stockEntry.value.to_warehouse,
+		})),
 		name: stockEntry.value.name,
 	}
-	let res = await store.insert<StockEntry>('Stock Entry', body)
-	if (res?.data?.name) {
-		stockEntry.value.name = res.data.name
+	let res: DocActionResponse<StockEntry>
+
+	if (body.name) {
+		res = await store.update<StockEntry>('Stock Entry', body.name, body)
+	} else {
+		res = await store.insert<StockEntry>('Stock Entry', body)
 	}
+	const { data, response } = res
+	if (data?.name) stockEntry.value.name = data.name
+
+	return { data, response }
 }
 
 const repack = async () => {
@@ -147,30 +172,92 @@ const repack = async () => {
 	}
 }
 
+const addItem = () => {
+	if (!currentItem.value.item_code || !currentItem.value.qty) {
+		toast.error('Please select or scan an Item and set its quantity')
+		return
+	}
+	if (!stockEntry.value.from_warehouse && !stockEntry.value.to_warehouse) {
+		toast.error('Please select source or target warehouses')
+		return
+	}
+	items.value.push(
+		{
+			label: currentItem.value.item_code,
+			count: { count: currentItem.value.qty },
+			description: `From ${stockEntry.value.from_warehouse} to ${stockEntry.value.to_warehouse}`,
+		}
+	)
+	currentItem.value = { item_code: '', qty: 0, bom: '' }
+}
+
+const clearItem = () => {
+	currentItem.value.bom = ""
+	items.value = []
+	store.$patch(state => state.cache.mappers.repack.items = [])
+}
+
 const controlButtons = computed((): ControlButton[] => {
-	if (!stockEntry.value.items.length || !stockEntry.value.from_warehouse || !stockEntry.value.to_warehouse) return []
+	const buttons = [
+		{ label: 'CLEAN', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: clearItem },
+		{ label: 'ADD', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: addItem },
+	]
+	if (!(stockEntry.value.items.length || stockEntry.value.bom) || !stockEntry.value.from_warehouse || !stockEntry.value.to_warehouse) return buttons
 	return [
-		{ label: 'SAVE', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: create },
-		{ label: 'REPACK', disabled: !stockEntry.value.name, color: { background: 'var(--sc-success)', text: 'var(--sc-btn-color)' }, action: repack },
+		{
+			label: 'REPACK',
+			disabled: !stockEntry.value.name,
+			hidden: !stockEntry.value.name,
+			color: {
+				background: '#4791FF',
+				text: 'var(--sc-btn-color)'
+			},
+			action: repack
+		},
+		{
+			label: 'SAVE',
+			color: {
+				background: '#4791FF',
+				text: 'var(--sc-btn-color)'
+			},
+			action: create
+		},
+		...buttons,
 	]
 })
 
 watch(
 	() => store.cache.mappers['repack']?.items,
 	(newItems: ListViewItem[]) => {
+		if (currentItem.value.bom) return
 		if (!newItems) return
 
 		const item = newItems[0]
 		if (!item) return
 		itemList.value = [item.item_code]
 		const qty = item.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
+
 		if (!currentItem.value.item_code) currentItem.value = { ...item, qty }
 		else currentItem.value = { ...item, qty }
-
-		store.$patch(state => state.cache.mappers.repack.items = [])
-		//componentKey.value++
 	},
 	{ immediate: true, deep: true }
+)
+
+watch(
+	() => currentItem.value.bom,
+	async (bom) => {
+		const listBom = await getStockEntryItems(bom);
+		items.value = listBom.map(bomItem => ({
+			label: bomItem.description,
+			count: { count: bomItem.qty },
+			description: `${bomItem.default_warehouse}`,
+		}))
+		stockEntry.value.items = listBom.map(bomItem => ({
+			item_code: bomItem.description,
+			qty: bomItem.qty,
+			s_warehouse: bomItem.default_warehouse,
+		}))
+	}
 )
 </script>
 <style scoped>

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -41,7 +41,6 @@
 	<div class="begin" v-else>
 		<span>Scan Items, Select Warehouses, and Set Qty to Begin</span>
 	</div>
-
 	<ControlButtons :buttons="controlButtons" />
 </template>
 
@@ -96,29 +95,6 @@ const loadBOMs = async () => {
 	bomList.value = boms.map(bom => bom.name)
 }
 
-const getStockEntryItems = async (bomName: string, company = "Ambrosia Pie Company", qty = 1, purpose = "Manufacture") => {
-	try {
-		const response = await httpStore.get("/api/method/erpnext.manufacturing.doctype.bom.bom.get_bom_items", {
-			bom: bomName,
-			company,
-			fetch_exploded: 1,
-			qty,
-			purpose,
-		})
-		const { message }: { message: BomItem[] } = await response.json()
-
-		if (!message) {
-			console.error("La respuesta no contiene 'message'", response)
-			return []
-		}
-
-		return message
-	} catch (error) {
-		console.error("Error en getStockEntryItems:", error)
-		return []
-	}
-}
-
 const loadWarehouses = async () => {
 	const warehouses = await store.getAll<{ name: string }[]>('Warehouse', {
 		filters: JSON.stringify([['is_group', '!=', '1']]),
@@ -126,11 +102,11 @@ const loadWarehouses = async () => {
 	warehouseList.value = warehouses.map(warehouse => warehouse.name)
 }
 
-const clearField = (field: 'from_warehouse' | 'to_warehouse') => stockEntry.value[field] = ''
+const clearField = (field: 'from_warehouse' | 'to_warehouse') => store.$patch(state => state.cache.mappers.repack[field] = '')
 
 const clearCurrentItem = (field: 'item_code' | 'bom') => currentItem.value[field] = ''
 
-const substractCurrentItem = () => currentItem.value.qty--
+const substractCurrentItem = () => currentItem.value.qty > 0 ? currentItem.value.qty-- : 0
 
 const addCurrentItem = () => currentItem.value.qty++
 
@@ -152,7 +128,7 @@ const create = async () => {
 		res = await store.insert<StockEntry>('Stock Entry', body)
 	}
 	const { data, response } = res
-	if (data?.name) stockEntry.value.name = data.name
+	if (data?.name) store.$patch(state => state.cache.mappers.repack.name = data.name)
 
 	return { data, response }
 }
@@ -181,18 +157,30 @@ const addItem = () => {
 		toast.error('Please select source or target warehouses')
 		return
 	}
+	if (stockEntry.value.from_warehouse && stockEntry.value.to_warehouse) {
+		toast.error('Please select only source or target warehouse')
+		return
+	}
 	items.value.push(
 		{
 			label: currentItem.value.item_code,
 			count: { count: currentItem.value.qty },
-			description: `From ${stockEntry.value.from_warehouse} to ${stockEntry.value.to_warehouse}`,
+			description: stockEntry.value.from_warehouse ? `From ${stockEntry.value.from_warehouse}` : `To ${stockEntry.value.to_warehouse}`,
 		}
 	)
+	const existingItem = stockEntry.value.items.find(item => item.item_code === currentItem.value.item_code)
+	if (existingItem) {
+		existingItem.s_warehouse = stockEntry.value.from_warehouse
+		existingItem.t_warehouse = stockEntry.value.to_warehouse
+	}
+
 	currentItem.value = { item_code: '', qty: 0, bom: '' }
+	clearField('from_warehouse')
+	clearField('to_warehouse')
 }
 
 const clearItem = () => {
-	currentItem.value.bom = ""
+	currentItem.value.bom = ''
 	items.value = []
 	store.$patch(state => state.cache.mappers.repack.items = [])
 }
@@ -202,7 +190,7 @@ const controlButtons = computed((): ControlButton[] => {
 		{ label: 'CLEAN', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: clearItem },
 		{ label: 'ADD', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: addItem },
 	]
-	if (!(stockEntry.value.items.length || stockEntry.value.bom) || !stockEntry.value.from_warehouse || !stockEntry.value.to_warehouse) return buttons
+	if (stockEntry.value.items.length === 0) return buttons
 	return [
 		{
 			label: 'REPACK',
@@ -229,11 +217,13 @@ const controlButtons = computed((): ControlButton[] => {
 watch(
 	() => store.cache.mappers['repack']?.items,
 	(newItems: ListViewItem[]) => {
-		if (currentItem.value.bom) return
 		if (!newItems) return
+		if (currentItem.value.bom) return
 
-		const item = newItems[0]
+		const item = newItems.pop()
 		if (!item) return
+		if (items.value.some(i => i.label === item.item_code)) return
+
 		itemList.value = [item.item_code]
 		const qty = item.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
 
@@ -246,17 +236,20 @@ watch(
 watch(
 	() => currentItem.value.bom,
 	async (bom) => {
-		const listBom = await getStockEntryItems(bom);
+		if (!currentItem.value.bom) return
+		const listBom = await store.getStockEntryItems(bom);
 		items.value = listBom.map(bomItem => ({
 			label: bomItem.description,
 			count: { count: bomItem.qty },
 			description: `${bomItem.default_warehouse}`,
 		}))
-		stockEntry.value.items = listBom.map(bomItem => ({
-			item_code: bomItem.description,
-			qty: bomItem.qty,
-			s_warehouse: bomItem.default_warehouse,
-		}))
+		store.$patch(state =>
+			state.cache.mappers.repack.items = listBom.map(bomItem => ({
+				item_code: bomItem.description,
+				qty: bomItem.qty,
+				s_warehouse: bomItem.default_warehouse,
+			}))
+		)
 	}
 )
 </script>

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -12,11 +12,7 @@
 		<div class="container">
 			<template v-if="itemList">
 				<div class="dd-container">
-					<ADropdown
-						label="Item to Repack"
-						:items="itemList"
-						v-model="currentItem.item_code"
-						:isAsync="true"
+					<ADropdown label="Item to Repack" :items="itemList" v-model="currentItem.item_code" :isAsync="true"
 						:filterFunction="loadItems" />
 					<BeamBtn class="clear-button" @click="clearCurrentItem('item_code')"> X </BeamBtn>
 				</div>
@@ -184,8 +180,23 @@ const clearItem = () => {
 
 const controlButtons = computed((): ControlButton[] => {
 	const buttons = [
-		{ label: 'CLEAN', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: clearItem },
-		{ label: 'ADD', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: addItem },
+		{
+			label: 'CLEAN',
+			color: {
+				background: '#4791FF',
+				text: 'var(--sc-btn-color)',
+			},
+			action: clearItem,
+			hidden: items.value.length === 0,
+		},
+		{
+			label: 'ADD',
+			color: {
+				background: '#4791FF',
+				text: 'var(--sc-btn-color)',
+			},
+			action: addItem,
+		},
 	]
 
 	if (items.value.length === 0) return buttons

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -162,7 +162,7 @@ watch(
 
 		const item = newItems[0]
 		if (!item) return
-
+		itemList.value = [item.item_code]
 		const qty = item.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
 		if (!currentItem.value.item_code) currentItem.value = { ...item, qty }
 		else currentItem.value = { ...item, qty }

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -11,7 +11,6 @@
 	<div class="move">
 		<div class="container">
 			<template v-if="itemList">
-				{{ console.log(0, currentItem) }}
 				<div class="dd-container">
 					<ADropdown
 						label="Item to Repack"
@@ -159,14 +158,12 @@ const controlButtons = computed((): ControlButton[] => {
 watch(
 	() => store.cache.mappers['repack']?.items,
 	(newItems: ListViewItem[]) => {
-		console.log(1, newItems)
 		if (!newItems) return
 
 		const item = newItems[0]
 		if (!item) return
 
 		const qty = item.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
-		console.log(2, item)
 		if (!currentItem.value.item_code) currentItem.value = { ...item, qty }
 		else currentItem.value = { ...item, qty }
 

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -8,7 +8,7 @@
 		</template>
 	</Navbar>
 
-	<div class="move">
+	<div class="repack">
 		<div class="container">
 			<template v-if="itemList">
 				<div class="dd-container">
@@ -16,7 +16,7 @@
 						:filterFunction="loadItems" />
 					<BeamBtn class="clear-button" @click="clearCurrentItem('item_code')"> X </BeamBtn>
 				</div>
-				<div class="dd-container wrapper">
+				<div class="dd-container">
 					<BeamBtn class="clear-button" @click="substractCurrentItem"> - </BeamBtn>
 					<ANumericInput label="Quantity" v-model="currentItem.qty" />
 					<BeamBtn class="clear-button" @click="addCurrentItem"> + </BeamBtn>
@@ -236,24 +236,29 @@ watch(
 			label: bomItem.description,
 			count: { count: bomItem.qty },
 			description: `From ${bomItem.default_warehouse}`,
+			item_code: bomItem.description,
+			qty: bomItem.qty,
+			s_warehouse: bomItem.default_warehouse,
 		}))
-		store.$patch(state =>
-			state.cache.mappers.repack.items = listBom.map(bomItem => ({
-				item_code: bomItem.description,
-				qty: bomItem.qty,
-				s_warehouse: bomItem.default_warehouse,
-			}))
-		)
 	}
 )
 </script>
-<style scoped>
-.move {
+<style>
+.repack {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	min-height: 200px;
 	padding: 20px;
+}
+
+.repack .autocomplete input,
+.autocomplete-results {
+	font-size: 150%;
+}
+
+.repack .input-wrapper label {
+	margin: calc(-2.5rem - calc(2.15rem / 2)) 0 0 1ch !important;
 }
 
 .container {
@@ -270,12 +275,19 @@ watch(
 	justify-content: space-between;
 }
 
-/* .wrapper .aform_form-element input {
+.dd-container .aform_form-element input {
+	border-color: red;
 	font-size: 150% !important;
 	outline: 1px solid transparent !important;
 	border: 1px solid var(--sc-input-border-color) !important;
 	border-radius: .25rem !important;
-} */
+	width: 90% !important;
+}
+
+.dd-container .aform_form-element {
+	margin-bottom: 0 !important;
+	margin-top: 10px !important;
+}
 
 .clear-button {
 	margin-top: 10px;

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -47,13 +47,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { useBeamStore } from '@/stores/beam'
-import { useHttpStore } from '@/stores/http.js'
 import { useBeamToast } from '@/utils/toast.js'
 import { ListViewItem } from '@stonecrop/beam'
 import ControlButtons from '@/components/ControlButtons.vue'
 import type { ControlButton, DocActionResponse, StockEntry, BomItem } from '@/types'
 
-const httpStore = useHttpStore()
 const toast = useBeamToast()
 const store = useBeamStore()
 const currentItem = ref({ item_code: '', qty: 0, bom: '' })
@@ -217,6 +215,7 @@ const controlButtons = computed((): ControlButton[] => {
 watch(
 	() => store.cache.mappers['repack']?.items,
 	(newItems: ListViewItem[]) => {
+		// Update items list on Scan
 		if (!newItems) return
 		if (currentItem.value.bom) return
 
@@ -236,12 +235,13 @@ watch(
 watch(
 	() => currentItem.value.bom,
 	async (bom) => {
+		// Update items list on BOM selection
 		if (!currentItem.value.bom) return
 		const listBom = await store.getStockEntryItems(bom);
 		items.value = listBom.map(bomItem => ({
 			label: bomItem.description,
 			count: { count: bomItem.qty },
-			description: `${bomItem.default_warehouse}`,
+			description: `From ${bomItem.default_warehouse}`,
 		}))
 		store.$patch(state =>
 			state.cache.mappers.repack.items = listBom.map(bomItem => ({

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -9,17 +9,39 @@
 	</Navbar>
 
 	<div class="move">
-		<!-- <ADropdown label="Item to Repack" :items="itemList" v-model="stockEntry.item" />
-		<AInput label="Qty" type="number" v-model="stockEntry.qty" />
-		<ADropdown label="BOM (Optional)" :items="bomList" v-model="stockEntry.bom" /> -->
-
-		<div class="dropdown-container">
-			<ADropdown label="Source Warehouse" :items="warehouseList" v-model="stockEntry.from_warehouse" />
-			<BeamBtn class="clear-button" @click="clearField('from_warehouse')"> X </BeamBtn>
-		</div>
-		<div class="dropdown-container">
-			<ADropdown label="Target Warehouse" :items="warehouseList" v-model="stockEntry.to_warehouse" />
-			<BeamBtn class="clear-button" @click="clearField('to_warehouse')"> X </BeamBtn>
+		<div class="container">
+			<template v-if="itemList">
+				{{ console.log(0, currentItem) }}
+				<div class="dd-container">
+					<ADropdown
+						label="Item to Repack"
+						:items="itemList"
+						v-model="currentItem.item_code"
+						:isAsync="true"
+						:filterFunction="loadItems"
+					/>
+					<BeamBtn class="clear-button" @click="clearCurrentItem"> X </BeamBtn>
+				</div>
+				<div class="dd-container wrapper">
+					<BeamBtn class="clear-button" @click="substractCurrentItem"> - </BeamBtn>
+					<!-- <div class="wrapper">
+						<input label="Qty" type="number" v-model="currentItem.qty" />
+					</div> -->
+					<ANumericInput label="Quantity" v-model="currentItem.qty" />
+					<BeamBtn class="clear-button" @click="addCurrentItem"> + </BeamBtn>
+				</div>
+				<div class="dd-container">
+					<ADropdown label="BOM (Optional)" :items="bomList" v-model="currentItem.bom" />
+				</div>
+			</template>
+			<div class="dd-container">
+				<ADropdown label="Source Warehouse" :items="warehouseList" v-model="stockEntry.from_warehouse" />
+				<BeamBtn class="clear-button" @click="clearField('from_warehouse')"> X </BeamBtn>
+			</div>
+			<div class="dd-container">
+				<ADropdown label="Target Warehouse" :items="warehouseList" v-model="stockEntry.to_warehouse" />
+				<BeamBtn class="clear-button" @click="clearField('to_warehouse')"> X </BeamBtn>
+			</div>
 		</div>
 	</div>
 
@@ -35,10 +57,11 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useBeamStore } from '@/stores/beam'
 import ControlButtons from '@/components/ControlButtons.vue'
-import type { ListViewItem } from '@stonecrop/beam'
+import { ListViewItem } from '@stonecrop/beam'
 import type { ControlButton, StockEntry } from '@/types'
 
 const store = useBeamStore()
+const currentItem = ref<ListViewItem>({ item_code: '', qty: 0, bom: '' })
 const items = ref<ListViewItem[]>([])
 const componentKey = ref(0)
 const stockEntry = computed(
@@ -58,14 +81,18 @@ const warehouseList = ref<string[]>([])
 
 onMounted(async () => {
 	store.$patch(state => state.cache.mappers['repack'] = stockEntry.value)
-	await loadItems()
 	await loadBOMs()
 	await loadWarehouses()
 })
 
-const loadItems = async () => {
-	const itemsData = await store.getAll<{ name: string }[]>('Item')
-	itemList.value = itemsData.map(item => item.name)
+const loadItems = async (search: string) => {
+	if (!search) return []
+	const itemsData = await store.getAll<{ name: string }[]>('Item', {
+		filters: JSON.stringify([['item_code', 'like', `${search}%`]]),
+	})
+	const itemsMapped = itemsData.map(item => item.name)
+	itemList.value = itemsMapped
+	return itemsMapped.filter(item => item.toLocaleLowerCase().startsWith(search.toLocaleLowerCase()))
 }
 
 const loadBOMs = async () => {
@@ -80,9 +107,13 @@ const loadWarehouses = async () => {
 	warehouseList.value = warehouses.map(warehouse => warehouse.name)
 }
 
-const clearField = (field: 'from_warehouse' | 'to_warehouse') => {
-	stockEntry.value[field] = ''
-}
+const clearField = (field: 'from_warehouse' | 'to_warehouse') => stockEntry.value[field] = ''
+
+const clearCurrentItem = () => currentItem.value = { item_code: '', qty: 0, bom: '' }
+
+const addCurrentItem = () => currentItem.value.qty++
+
+const substractCurrentItem = () => currentItem.value.qty--
 
 const update = () => {
 	// TODO
@@ -117,18 +148,6 @@ const repack = async () => {
 	}
 }
 
-watch(
-	() => store.cache.mappers['repack']?.items,
-	newItems => {
-		items.value = (newItems || []).map(s => ({
-			...s,
-			label: s.item_code,
-			count: { count: s.qty },
-		}))
-		componentKey.value++
-	},
-	{ immediate: true, deep: true }
-)
 const controlButtons = computed((): ControlButton[] => {
 	if (!stockEntry.value.items.length || !stockEntry.value.from_warehouse || !stockEntry.value.to_warehouse) return []
 	return [
@@ -136,4 +155,66 @@ const controlButtons = computed((): ControlButton[] => {
 		{ label: 'REPACK', disabled: !stockEntry.value.name, color: { background: 'var(--sc-success)', text: 'var(--sc-btn-color)' }, action: repack },
 	]
 })
+
+watch(
+	() => store.cache.mappers['repack']?.items,
+	(newItems: ListViewItem[]) => {
+		console.log(1, newItems)
+		if (!newItems) return
+
+		const item = newItems[0]
+		if (!item) return
+
+		const qty = item.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
+		console.log(2, item)
+		if (!currentItem.value.item_code) currentItem.value = { ...item, qty }
+		else currentItem.value = { ...item, qty }
+
+		store.$patch(state => state.cache.mappers.repack.items = [])
+		//componentKey.value++
+	},
+	{ immediate: true, deep: true }
+)
 </script>
+<style scoped>
+.move {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	min-height: 200px;
+	padding: 20px;
+}
+
+.container {
+	display: flex;
+	flex-direction: column;
+	width: 80vh;
+}
+
+.dd-container {
+	display: flex;
+	width: 100%;
+	margin-top: 1rem;
+	gap: 10px;
+	justify-content: space-between;
+}
+
+.wrapper .aform_form-element input {
+	font-size: 150% !important;
+	outline: 1px solid transparent !important;
+	border: 1px solid var(--sc-input-border-color) !important;
+	/* padding: 1ch .5ch .5ch 1ch; */
+	border-radius: .25rem !important;
+}
+
+/* .wrapper {
+	flex: 1;
+	display: flex;
+	justify-content: center;
+} */
+
+.clear-button {
+	margin-top: 10px;
+	flex-shrink: 0;
+}
+</style>

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -199,22 +199,14 @@ watch(
 	justify-content: space-between;
 }
 
-.wrapper .aform_form-element input {
+/* .wrapper .aform_form-element input {
 	font-size: 150% !important;
 	outline: 1px solid transparent !important;
 	border: 1px solid var(--sc-input-border-color) !important;
-	/* padding: 1ch .5ch .5ch 1ch; */
 	border-radius: .25rem !important;
-}
-
-/* .wrapper {
-	flex: 1;
-	display: flex;
-	justify-content: center;
 } */
 
 .clear-button {
 	margin-top: 10px;
-	flex-shrink: 0;
 }
 </style>

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -50,7 +50,7 @@ import { useBeamStore } from '@/stores/beam'
 import { useBeamToast } from '@/utils/toast.js'
 import { ListViewItem } from '@stonecrop/beam'
 import ControlButtons from '@/components/ControlButtons.vue'
-import type { ControlButton, DocActionResponse, StockEntry, BomItem } from '@/types'
+import type { ControlButton, DocActionResponse, StockEntry } from '@/types'
 
 const toast = useBeamToast()
 const store = useBeamStore()
@@ -111,11 +111,7 @@ const addCurrentItem = () => currentItem.value.qty++
 const create = async () => {
 	const body: StockEntry = {
 		stock_entry_type: 'Repack',
-		items: stockEntry.value.items.map(i => ({
-			...i,
-			s_warehouse: stockEntry.value.from_warehouse,
-			t_warehouse: stockEntry.value.to_warehouse,
-		})),
+		items: items.value,
 		name: stockEntry.value.name,
 	}
 	let res: DocActionResponse<StockEntry>
@@ -143,6 +139,7 @@ const repack = async () => {
 				to_warehouse: '',
 			}
 		})
+		items.value = []
 	}
 }
 
@@ -164,13 +161,12 @@ const addItem = () => {
 			label: currentItem.value.item_code,
 			count: { count: currentItem.value.qty },
 			description: stockEntry.value.from_warehouse ? `From ${stockEntry.value.from_warehouse}` : `To ${stockEntry.value.to_warehouse}`,
+			item_code: currentItem.value.item_code,
+			qty: currentItem.value.qty,
+			s_warehouse: stockEntry.value.from_warehouse,
+			t_warehouse: stockEntry.value.to_warehouse,
 		}
 	)
-	const existingItem = stockEntry.value.items.find(item => item.item_code === currentItem.value.item_code)
-	if (existingItem) {
-		existingItem.s_warehouse = stockEntry.value.from_warehouse
-		existingItem.t_warehouse = stockEntry.value.to_warehouse
-	}
 
 	currentItem.value = { item_code: '', qty: 0, bom: '' }
 	clearField('from_warehouse')
@@ -188,7 +184,7 @@ const controlButtons = computed((): ControlButton[] => {
 		{ label: 'CLEAN', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: clearItem },
 		{ label: 'ADD', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: addItem },
 	]
-	if (stockEntry.value.items.length === 0) return buttons
+	if (items.value.length === 0) return buttons
 	return [
 		{
 			label: 'REPACK',
@@ -219,15 +215,13 @@ watch(
 		if (!newItems) return
 		if (currentItem.value.bom) return
 
-		const item = newItems.pop()
-		if (!item) return
-		if (items.value.some(i => i.label === item.item_code)) return
+		const newItem = newItems[newItems.length - 1]
+		if (!newItem) return
+		if (items.value.some(i => i.label === newItem.item_code)) return
+		itemList.value = [newItem.item_code]
+		const qty = newItem.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
 
-		itemList.value = [item.item_code]
-		const qty = item.item_code === currentItem.value.item_code ? currentItem.value.qty + 1 : 1
-
-		if (!currentItem.value.item_code) currentItem.value = { ...item, qty }
-		else currentItem.value = { ...item, qty }
+		currentItem.value = { ...newItem, qty }
 	},
 	{ immediate: true, deep: true }
 )

--- a/beam/www/beam/pages/Repack.vue
+++ b/beam/www/beam/pages/Repack.vue
@@ -1,5 +1,5 @@
 <template>
-	<Navbar @click="handlePrimaryAction">
+	<Navbar>
 		<template #title>
 			<h1>Repack</h1>
 		</template>
@@ -8,24 +8,132 @@
 		</template>
 	</Navbar>
 
-	<!-- <scale>
-		<readout :mqtt="" />
-	</scale> -->
+	<div class="move">
+		<!-- <ADropdown label="Item to Repack" :items="itemList" v-model="stockEntry.item" />
+		<AInput label="Qty" type="number" v-model="stockEntry.qty" />
+		<ADropdown label="BOM (Optional)" :items="bomList" v-model="stockEntry.bom" /> -->
+
+		<div class="dropdown-container">
+			<ADropdown label="Source Warehouse" :items="warehouseList" v-model="stockEntry.from_warehouse" />
+			<BeamBtn class="clear-button" @click="clearField('from_warehouse')"> X </BeamBtn>
+		</div>
+		<div class="dropdown-container">
+			<ADropdown label="Target Warehouse" :items="warehouseList" v-model="stockEntry.to_warehouse" />
+			<BeamBtn class="clear-button" @click="clearField('to_warehouse')"> X </BeamBtn>
+		</div>
+	</div>
+
+	<ListView :items="items" :key="componentKey" @update="update" />
+	<div class="begin" v-if="items.length == 0">
+		<span>Scan Items, Select Warehouses, and Set Qty to Begin</span>
+	</div>
+
+	<ControlButtons :buttons="controlButtons" />
 </template>
 
 <script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { useBeamStore } from '@/stores/beam'
+import ControlButtons from '@/components/ControlButtons.vue'
 import type { ListViewItem } from '@stonecrop/beam'
-import { ref } from 'vue'
-import { useRoute } from 'vue-router'
+import type { ControlButton, StockEntry } from '@/types'
 
-import type { StockEntry } from '@/types'
-
-const route = useRoute()
-const stockEntryId = route.params.id
+const store = useBeamStore()
 const items = ref<ListViewItem[]>([])
-const stockEntry = ref<Partial<StockEntry>>({})
+const componentKey = ref(0)
+const stockEntry = computed(
+	(): StockEntry =>
+		(store.cache.mappers['repack'] as StockEntry) || {
+			name: '',
+			stock_entry_type: 'Repack',
+			items: [],
+			from_warehouse: '',
+			to_warehouse: '',
+		}
+)
 
-const handlePrimaryAction = () => {
-	throw new Error('Not implemented')
+const itemList = ref<string[]>([])
+const bomList = ref<string[]>([])
+const warehouseList = ref<string[]>([])
+
+onMounted(async () => {
+	store.$patch(state => state.cache.mappers['repack'] = stockEntry.value)
+	await loadItems()
+	await loadBOMs()
+	await loadWarehouses()
+})
+
+const loadItems = async () => {
+	const itemsData = await store.getAll<{ name: string }[]>('Item')
+	itemList.value = itemsData.map(item => item.name)
 }
+
+const loadBOMs = async () => {
+	const boms = await store.getAll<{ name: string }[]>('BOM')
+	bomList.value = boms.map(bom => bom.name)
+}
+
+const loadWarehouses = async () => {
+	const warehouses = await store.getAll<{ name: string }[]>('Warehouse', {
+		filters: JSON.stringify([['is_group', '!=', '1']]),
+	})
+	warehouseList.value = warehouses.map(warehouse => warehouse.name)
+}
+
+const clearField = (field: 'from_warehouse' | 'to_warehouse') => {
+	stockEntry.value[field] = ''
+}
+
+const update = () => {
+	// TODO
+}
+
+const create = async () => {
+	const body: StockEntry = {
+		stock_entry_type: 'Repack',
+		items: stockEntry.value.items || [],
+		from_warehouse: stockEntry.value.from_warehouse,
+		to_warehouse: stockEntry.value.to_warehouse,
+		name: stockEntry.value.name,
+	}
+	let res = await store.insert<StockEntry>('Stock Entry', body)
+	if (res?.data?.name) {
+		stockEntry.value.name = res.data.name
+	}
+}
+
+const repack = async () => {
+	const res = await store.submit<StockEntry>('Stock Entry', stockEntry.value.name || '')
+	if (res?.data) {
+		store.$patch(state => {
+			state.cache.mappers['repack'] = {
+				name: '',
+				stock_entry_type: 'Repack',
+				items: [],
+				from_warehouse: '',
+				to_warehouse: '',
+			}
+		})
+	}
+}
+
+watch(
+	() => store.cache.mappers['repack']?.items,
+	newItems => {
+		items.value = (newItems || []).map(s => ({
+			...s,
+			label: s.item_code,
+			count: { count: s.qty },
+		}))
+		componentKey.value++
+	},
+	{ immediate: true, deep: true }
+)
+const controlButtons = computed((): ControlButton[] => {
+	if (!stockEntry.value.items.length || !stockEntry.value.from_warehouse || !stockEntry.value.to_warehouse) return []
+	return [
+		{ label: 'SAVE', color: { background: '#4791FF', text: 'var(--sc-btn-color)' }, action: create },
+		{ label: 'REPACK', disabled: !stockEntry.value.name, color: { background: 'var(--sc-success)', text: 'var(--sc-btn-color)' }, action: repack },
+	]
+})
 </script>

--- a/beam/www/beam/stores/beam.ts
+++ b/beam/www/beam/stores/beam.ts
@@ -9,6 +9,7 @@ import { useHttpStore } from '@/stores/http.js'
 import type {
 	BeamCache,
 	BeamHome,
+	BomItem,
 	DeliveryNoteItem,
 	Demand,
 	FormContext,
@@ -249,6 +250,27 @@ export const useBeamStore = defineStore('beam', () => {
 		return message
 	}
 
+	const getStockEntryItems = async (bomName: string, qty = 1, purpose = "Manufacture") => {
+		try {
+			const homeData = await getHome()
+			const company = homeData.data.company
+			const response = await httpStore.get("/api/method/erpnext.manufacturing.doctype.bom.bom.get_bom_items", {
+				bom: bomName,
+				company,
+				fetch_exploded: 1,
+				qty,
+				purpose,
+			})
+			const { message }: { message: BomItem[] } = await response.json()
+			if (!message) return []
+	
+			return message
+		} catch (error) {
+			console.error(error)
+			return []
+		}
+	}
+
 	const logout = async () => {
 		await httpStore.get(LOGOUT_URL)
 		window.location.href = '/login?redirect-to=/beam#'
@@ -294,6 +316,7 @@ export const useBeamStore = defineStore('beam', () => {
 		getMappedStockEntry,
 		getOne,
 		getReceiving,
+		getStockEntryItems,
 		logout,
 		makeNewDoc,
 		scan,

--- a/beam/www/beam/stores/beam.ts
+++ b/beam/www/beam/stores/beam.ts
@@ -43,6 +43,7 @@ export const useBeamStore = defineStore('beam', () => {
 	const recordsPerPage = 20
 	const cache = ref<BeamCache>({ mappers: {} })
 	const form = ref<Partial<ParentDoctypes>>({})
+	const warehouseList = ref()
 	const scanner = reactive({
 		config: {} as ScanConfig,
 		context: {} as ScanContext,
@@ -111,6 +112,12 @@ export const useBeamStore = defineStore('beam', () => {
 		} else if (meta.view === 'form' && scanner.config.frm.includes(meta.doctype)) {
 			scanner.context = { frm: meta.doctype }
 		}
+	}
+
+	const setWarehouses = async () => {
+		warehouseList.value = await getAll<{ name: string }[]>('Warehouse', {
+			fields: JSON.stringify(['company', 'disabled', 'is_group', 'name', 'warehouse_name']),
+		})
 	}
 
 	const getOne = async <T>(doctype: string, name: string) => {
@@ -295,12 +302,14 @@ export const useBeamStore = defineStore('beam', () => {
 		cache,
 		form,
 		scanner,
+		warehouseList,
 
 		// store context actions
 		getScanDoctypes,
 		setForm,
 		setMappedDoc,
 		setScanContext,
+		setWarehouses,
 
 		// document workflow actions
 		cancel,

--- a/beam/www/beam/stores/beam.ts
+++ b/beam/www/beam/stores/beam.ts
@@ -48,8 +48,8 @@ export const useBeamStore = defineStore('beam', () => {
 		context: {} as ScanContext,
 	})
 
-	const getScanDoctypes = async (params?: Record<string, any>) => {
-		const response = await httpStore.get(SCAN_CONFIG_URL, params)
+	const getScanDoctypes = async () => {
+		const response = await httpStore.get(SCAN_CONFIG_URL)
 		const { message }: { message: ScanConfig } = await response.json()
 		scanner.config = message
 	}
@@ -250,11 +250,11 @@ export const useBeamStore = defineStore('beam', () => {
 		return message
 	}
 
-	const getStockEntryItems = async (bomName: string, qty = 1, purpose = "Manufacture") => {
+	const getStockEntryItems = async (bomName: string, qty = 1, purpose = 'Manufacture') => {
 		try {
 			const homeData = await getHome()
 			const company = homeData.data.company
-			const response = await httpStore.get("/api/method/erpnext.manufacturing.doctype.bom.bom.get_bom_items", {
+			const response = await httpStore.get('/api/method/erpnext.manufacturing.doctype.bom.bom.get_bom_items', {
 				bom: bomName,
 				company,
 				fetch_exploded: 1,
@@ -263,7 +263,7 @@ export const useBeamStore = defineStore('beam', () => {
 			})
 			const { message }: { message: BomItem[] } = await response.json()
 			if (!message) return []
-	
+
 			return message
 		} catch (error) {
 			console.error(error)

--- a/beam/www/beam/stores/init.ts
+++ b/beam/www/beam/stores/init.ts
@@ -17,6 +17,7 @@ export const useInitStore = defineStore('init', () => {
 		await store.setForm(resolvedRoute)
 		await store.setMappedDoc(resolvedRoute)
 		await store.setScanContext(resolvedRoute)
+		await store.setWarehouses()
 
 		// only check store actions to control toggling dirty state (vs. all state mutations);
 		store.$onAction(({ name, after }) => {

--- a/beam/www/beam/stores/scan.ts
+++ b/beam/www/beam/stores/scan.ts
@@ -19,7 +19,7 @@ export const useScanStore = defineStore('scan', () => {
 
 	const documentId = computed(() => {
 		const currentRoute = store.router.currentRoute.value
-		return currentRoute.params.id || currentRoute.query.id || store.router.currentRoute.value?.name || ''
+		return currentRoute.params.id || currentRoute.query.id || currentRoute.name || ''
 	})
 
 	const mappedDoc = computed(() => store.cache.mappers[documentId.value])

--- a/beam/www/beam/stores/scan.ts
+++ b/beam/www/beam/stores/scan.ts
@@ -19,7 +19,7 @@ export const useScanStore = defineStore('scan', () => {
 
 	const documentId = computed(() => {
 		const currentRoute = store.router.currentRoute.value
-		return currentRoute.params.id || currentRoute.query.id || ''
+		return currentRoute.params.id || currentRoute.query.id || store.router.currentRoute.value?.name || ''
 	})
 
 	const mappedDoc = computed(() => store.cache.mappers[documentId.value])

--- a/beam/www/beam/stores/scan.ts
+++ b/beam/www/beam/stores/scan.ts
@@ -29,10 +29,11 @@ export const useScanStore = defineStore('scan', () => {
 		if (response && response.length > 0) {
 			let fn: Function
 			const action = response[0].action
-
 			const scanHooks = store.scanner.config.client
-			if (action in scanHooks) {
-				const path: string = scanHooks[action][0]
+
+			// an empty array indicates no additional client actions are registered
+			if (!Array.isArray(scanHooks) && action in scanHooks) {
+				const path = scanHooks[action][0]
 				// call (first) custom built callback registered in hooks
 				fn = path.split('.').reduce((previous, current) => previous[current], window)
 				return await fn(response)

--- a/beam/www/beam/types/beam.ts
+++ b/beam/www/beam/types/beam.ts
@@ -4,7 +4,7 @@
 import type { ListViewItem } from '@stonecrop/beam'
 import type { ButtonHTMLAttributes, CSSProperties, HTMLAttributes } from 'vue'
 
-import type { ParentDoctypesForStockTransfer } from '@/types/frappe.js'
+import type { ParentDoctypesForStockTransfer, StockEntry } from '@/types/frappe.js'
 
 export interface BeamWindow extends Window {
 	frappe: any
@@ -17,7 +17,11 @@ export type BeamHome = {
 }
 
 export type BeamCache = {
-	mappers: Record<string, ParentDoctypesForStockTransfer>
+	mappers: {
+		move?: StockEntry
+		repack?: StockEntry
+		[key: string]: ParentDoctypesForStockTransfer
+	}
 }
 
 export type ControlButton = {

--- a/beam/www/beam/types/frappe.ts
+++ b/beam/www/beam/types/frappe.ts
@@ -135,6 +135,28 @@ export type DeliveryNoteItem = ChildDoctype & {
 	warehouse?: string
 }
 
+export interface interface BomItem {
+    allow_alternative_item:        number;
+    amount:                        number;
+    cost_center:                   string;
+    default_warehouse:             string;
+    description:                   string;
+    expense_account:               string;
+    idx:                           number;
+    image:                         null;
+    include_item_in_manufacturing: number;
+    item_code:                     string;
+    item_group:                    string;
+    item_name:                     string;
+    operation:                     null;
+    project:                       null;
+    qty:                           number;
+    rate:                          number;
+    source_warehouse:              null;
+    sourced_by_supplier:           number;
+    stock_uom:                     string;
+}
+
 export type ParentDoctypesForStockTransfer = DeliveryNote | PurchaseReceipt | StockEntry
 export type ParentDoctypesWithItems = ParentDoctypesForStockTransfer | JobCard | WorkOrder
 export type ParentDoctypes = ParentDoctypesWithItems & Workstation

--- a/beam/www/beam/types/frappe.ts
+++ b/beam/www/beam/types/frappe.ts
@@ -136,21 +136,21 @@ export type DeliveryNoteItem = ChildDoctype & {
 }
 
 export type BomItem = {
-	allow_alternative_item: number;
-	amount: number;
-	cost_center: string;
-	default_warehouse: string;
-	description: string;
-	expense_account: string;
-	idx: number;
-	include_item_in_manufacturing: number;
-	item_code: string;
-	item_group: string;
-	item_name: string;
-	qty: number;
-	rate: number;
-	sourced_by_supplier: number;
-	stock_uom: string;
+	allow_alternative_item: number
+	amount: number
+	cost_center: string
+	default_warehouse: string
+	description: string
+	expense_account: string
+	idx: number
+	include_item_in_manufacturing: number
+	item_code: string
+	item_group: string
+	item_name: string
+	qty: number
+	rate: number
+	sourced_by_supplier: number
+	stock_uom: string
 }
 
 export type ParentDoctypesForStockTransfer = DeliveryNote | PurchaseReceipt | StockEntry

--- a/beam/www/beam/types/frappe.ts
+++ b/beam/www/beam/types/frappe.ts
@@ -135,26 +135,22 @@ export type DeliveryNoteItem = ChildDoctype & {
 	warehouse?: string
 }
 
-export interface interface BomItem {
-    allow_alternative_item:        number;
-    amount:                        number;
-    cost_center:                   string;
-    default_warehouse:             string;
-    description:                   string;
-    expense_account:               string;
-    idx:                           number;
-    image:                         null;
-    include_item_in_manufacturing: number;
-    item_code:                     string;
-    item_group:                    string;
-    item_name:                     string;
-    operation:                     null;
-    project:                       null;
-    qty:                           number;
-    rate:                          number;
-    source_warehouse:              null;
-    sourced_by_supplier:           number;
-    stock_uom:                     string;
+export type BomItem = {
+	allow_alternative_item: number;
+	amount: number;
+	cost_center: string;
+	default_warehouse: string;
+	description: string;
+	expense_account: string;
+	idx: number;
+	include_item_in_manufacturing: number;
+	item_code: string;
+	item_group: string;
+	item_name: string;
+	qty: number;
+	rate: number;
+	sourced_by_supplier: number;
+	stock_uom: string;
 }
 
 export type ParentDoctypesForStockTransfer = DeliveryNote | PurchaseReceipt | StockEntry

--- a/beam/www/beam/types/scan.ts
+++ b/beam/www/beam/types/scan.ts
@@ -53,7 +53,7 @@ export type ScanContext = {
 }
 
 export type ScanConfig = {
-	client?: Record<string, string[]>[]
+	client?: Record<string, string[]> | never[]
 	frm?: string[]
 	listview?: string[]
 	scannable_doctypes?: string[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0", "@babel/code-frame@^7.26.2":
+"@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
   integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
@@ -33,39 +33,40 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.26.0", "@babel/compat-data@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.5.tgz#df93ac37f4417854130e21d72c66ff3d4b897fc7"
-  integrity sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==
+"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.26.5", "@babel/compat-data@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.8.tgz#821c1d35641c355284d4a870b8a4a7b0c141e367"
+  integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
 
 "@babel/core@^7.24.4":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.0.tgz#d78b6023cc8f3114ccf049eb219613f74a747b40"
-  integrity sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.8.tgz#7742f11c75acea6b08a8e24c5c0c8c89e89bf53e"
+  integrity sha512-l+lkXCHS6tQEc5oUpK28xBOZ6+HwaH7YwoYQbLFiYb4nS2/l1tKnZEtEWkD0GuiYdvArf9qBS0XlQGXzPMsNqQ==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.26.0"
-    "@babel/generator" "^7.26.0"
-    "@babel/helper-compilation-targets" "^7.25.9"
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.8"
+    "@babel/helper-compilation-targets" "^7.26.5"
     "@babel/helper-module-transforms" "^7.26.0"
-    "@babel/helpers" "^7.26.0"
-    "@babel/parser" "^7.26.0"
-    "@babel/template" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
-    "@babel/types" "^7.26.0"
+    "@babel/helpers" "^7.26.7"
+    "@babel/parser" "^7.26.8"
+    "@babel/template" "^7.26.8"
+    "@babel/traverse" "^7.26.8"
+    "@babel/types" "^7.26.8"
+    "@types/gensync" "^1.0.0"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.26.0", "@babel/generator@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.5.tgz#e44d4ab3176bbcaf78a5725da5f1dc28802a9458"
-  integrity sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==
+"@babel/generator@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.8.tgz#f9c5e770309e12e3099ad8271e52f6caa15442ab"
+  integrity sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==
   dependencies:
-    "@babel/parser" "^7.26.5"
-    "@babel/types" "^7.26.5"
+    "@babel/parser" "^7.26.8"
+    "@babel/types" "^7.26.8"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
@@ -77,7 +78,7 @@
   dependencies:
     "@babel/types" "^7.25.9"
 
-"@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.25.9":
+"@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.25.9", "@babel/helper-compilation-targets@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz#75d92bb8d8d51301c0d49e52a65c9a7fe94514d8"
   integrity sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==
@@ -110,7 +111,7 @@
     regexpu-core "^6.2.0"
     semver "^6.3.1"
 
-"@babel/helper-define-polyfill-provider@^0.6.2", "@babel/helper-define-polyfill-provider@^0.6.3":
+"@babel/helper-define-polyfill-provider@^0.6.3":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz#f4f2792fae2ef382074bc2d713522cf24e6ddb21"
   integrity sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==
@@ -208,20 +209,20 @@
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/helpers@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.0.tgz#30e621f1eba5aa45fe6f4868d2e9154d884119a4"
-  integrity sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==
+"@babel/helpers@^7.26.7":
+  version "7.26.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.7.tgz#fd1d2a7c431b6e39290277aacfd8367857c576a4"
+  integrity sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==
   dependencies:
     "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.0"
+    "@babel/types" "^7.26.7"
 
-"@babel/parser@^7.25.3", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.5.tgz#6fec9aebddef25ca57a935c86dbb915ae2da3e1f"
-  integrity sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==
+"@babel/parser@^7.25.3", "@babel/parser@^7.26.5", "@babel/parser@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.8.tgz#deca2b4d99e5e1b1553843b99823f118da6107c2"
+  integrity sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==
   dependencies:
-    "@babel/types" "^7.26.5"
+    "@babel/types" "^7.26.8"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.25.9":
   version "7.25.9"
@@ -296,14 +297,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-async-generator-functions@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz#1b18530b077d18a407c494eb3d1d72da505283a2"
-  integrity sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==
+"@babel/plugin-transform-async-generator-functions@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz#5e3991135e3b9c6eaaf5eff56d1ae5a11df45ff8"
+  integrity sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
     "@babel/helper-remap-async-to-generator" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/traverse" "^7.26.8"
 
 "@babel/plugin-transform-async-to-generator@^7.25.9":
   version "7.25.9"
@@ -314,7 +315,7 @@
     "@babel/helper-plugin-utils" "^7.25.9"
     "@babel/helper-remap-async-to-generator" "^7.25.9"
 
-"@babel/plugin-transform-block-scoped-functions@^7.25.9":
+"@babel/plugin-transform-block-scoped-functions@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz#3dc4405d31ad1cbe45293aa57205a6e3b009d53e"
   integrity sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==
@@ -401,7 +402,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-exponentiation-operator@^7.25.9":
+"@babel/plugin-transform-exponentiation-operator@^7.26.3":
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz#e29f01b6de302c7c2c794277a48f04a9ca7f03bc"
   integrity sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==
@@ -468,7 +469,7 @@
     "@babel/helper-module-transforms" "^7.25.9"
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-modules-commonjs@^7.25.9":
+"@babel/plugin-transform-modules-commonjs@^7.26.3":
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz#8f011d44b20d02c3de44d8850d971d8497f981fb"
   integrity sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==
@@ -509,7 +510,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-nullish-coalescing-operator@^7.25.9":
+"@babel/plugin-transform-nullish-coalescing-operator@^7.26.6":
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz#fbf6b3c92cb509e7b319ee46e3da89c5bedd31fe"
   integrity sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==
@@ -631,19 +632,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-template-literals@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz#6dbd4a24e8fad024df76d1fac6a03cf413f60fe1"
-  integrity sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==
+"@babel/plugin-transform-template-literals@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz#966b15d153a991172a540a69ad5e1845ced990b5"
+  integrity sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
 
-"@babel/plugin-transform-typeof-symbol@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz#224ba48a92869ddbf81f9b4a5f1204bbf5a2bc4b"
-  integrity sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==
+"@babel/plugin-transform-typeof-symbol@^7.26.7":
+  version "7.26.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz#d0e33acd9223744c1e857dbd6fa17bd0a3786937"
+  integrity sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
 
 "@babel/plugin-transform-unicode-escapes@^7.25.9":
   version "7.25.9"
@@ -677,13 +678,13 @@
     "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/preset-env@^7.11.0":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.26.0.tgz#30e5c6bc1bcc54865bff0c5a30f6d4ccdc7fa8b1"
-  integrity sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.26.8.tgz#7af0090829b606d2046db99679004731e1dc364d"
+  integrity sha512-um7Sy+2THd697S4zJEfv/U5MHGJzkN2xhtsR3T/SWRbVSic62nbISh51VVfU9JiO/L/Z97QczHTaFVkOU8IzNg==
   dependencies:
-    "@babel/compat-data" "^7.26.0"
-    "@babel/helper-compilation-targets" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/compat-data" "^7.26.8"
+    "@babel/helper-compilation-targets" "^7.26.5"
+    "@babel/helper-plugin-utils" "^7.26.5"
     "@babel/helper-validator-option" "^7.25.9"
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.25.9"
     "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.25.9"
@@ -695,9 +696,9 @@
     "@babel/plugin-syntax-import-attributes" "^7.26.0"
     "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
     "@babel/plugin-transform-arrow-functions" "^7.25.9"
-    "@babel/plugin-transform-async-generator-functions" "^7.25.9"
+    "@babel/plugin-transform-async-generator-functions" "^7.26.8"
     "@babel/plugin-transform-async-to-generator" "^7.25.9"
-    "@babel/plugin-transform-block-scoped-functions" "^7.25.9"
+    "@babel/plugin-transform-block-scoped-functions" "^7.26.5"
     "@babel/plugin-transform-block-scoping" "^7.25.9"
     "@babel/plugin-transform-class-properties" "^7.25.9"
     "@babel/plugin-transform-class-static-block" "^7.26.0"
@@ -708,7 +709,7 @@
     "@babel/plugin-transform-duplicate-keys" "^7.25.9"
     "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.25.9"
     "@babel/plugin-transform-dynamic-import" "^7.25.9"
-    "@babel/plugin-transform-exponentiation-operator" "^7.25.9"
+    "@babel/plugin-transform-exponentiation-operator" "^7.26.3"
     "@babel/plugin-transform-export-namespace-from" "^7.25.9"
     "@babel/plugin-transform-for-of" "^7.25.9"
     "@babel/plugin-transform-function-name" "^7.25.9"
@@ -717,12 +718,12 @@
     "@babel/plugin-transform-logical-assignment-operators" "^7.25.9"
     "@babel/plugin-transform-member-expression-literals" "^7.25.9"
     "@babel/plugin-transform-modules-amd" "^7.25.9"
-    "@babel/plugin-transform-modules-commonjs" "^7.25.9"
+    "@babel/plugin-transform-modules-commonjs" "^7.26.3"
     "@babel/plugin-transform-modules-systemjs" "^7.25.9"
     "@babel/plugin-transform-modules-umd" "^7.25.9"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.25.9"
     "@babel/plugin-transform-new-target" "^7.25.9"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.25.9"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.26.6"
     "@babel/plugin-transform-numeric-separator" "^7.25.9"
     "@babel/plugin-transform-object-rest-spread" "^7.25.9"
     "@babel/plugin-transform-object-super" "^7.25.9"
@@ -738,17 +739,17 @@
     "@babel/plugin-transform-shorthand-properties" "^7.25.9"
     "@babel/plugin-transform-spread" "^7.25.9"
     "@babel/plugin-transform-sticky-regex" "^7.25.9"
-    "@babel/plugin-transform-template-literals" "^7.25.9"
-    "@babel/plugin-transform-typeof-symbol" "^7.25.9"
+    "@babel/plugin-transform-template-literals" "^7.26.8"
+    "@babel/plugin-transform-typeof-symbol" "^7.26.7"
     "@babel/plugin-transform-unicode-escapes" "^7.25.9"
     "@babel/plugin-transform-unicode-property-regex" "^7.25.9"
     "@babel/plugin-transform-unicode-regex" "^7.25.9"
     "@babel/plugin-transform-unicode-sets-regex" "^7.25.9"
     "@babel/preset-modules" "0.1.6-no-external-plugins"
     babel-plugin-polyfill-corejs2 "^0.4.10"
-    babel-plugin-polyfill-corejs3 "^0.10.6"
+    babel-plugin-polyfill-corejs3 "^0.11.0"
     babel-plugin-polyfill-regenerator "^0.6.1"
-    core-js-compat "^3.38.1"
+    core-js-compat "^3.40.0"
     semver "^6.3.1"
 
 "@babel/preset-modules@0.1.6-no-external-plugins":
@@ -761,38 +762,38 @@
     esutils "^2.0.2"
 
 "@babel/runtime@^7.11.2", "@babel/runtime@^7.23.8", "@babel/runtime@^7.24.5", "@babel/runtime@^7.8.4":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
-  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  version "7.26.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.7.tgz#f4e7fe527cd710f8dc0618610b61b4b060c3c341"
+  integrity sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
-  integrity sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==
-  dependencies:
-    "@babel/code-frame" "^7.25.9"
-    "@babel/parser" "^7.25.9"
-    "@babel/types" "^7.25.9"
-
-"@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.5.tgz#6d0be3e772ff786456c1a37538208286f6e79021"
-  integrity sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==
+"@babel/template@^7.25.9", "@babel/template@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.26.8.tgz#db3898f47a17bab2f4c78ec1d0de38527c2ffe19"
+  integrity sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==
   dependencies:
     "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.5"
-    "@babel/parser" "^7.26.5"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.5"
+    "@babel/parser" "^7.26.8"
+    "@babel/types" "^7.26.8"
+
+"@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.8.tgz#0a8a9c2b7cc9519eed14275f4fd2278ad46e8cc9"
+  integrity sha512-nic9tRkjYH0oB2dzr/JoGIm+4Q6SuYeLEiIiZDwBscRMYFJ+tMAz98fuel9ZnbXViA2I0HVSSRRK8DW5fjXStA==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.8"
+    "@babel/parser" "^7.26.8"
+    "@babel/template" "^7.26.8"
+    "@babel/types" "^7.26.8"
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.26.5", "@babel/types@^7.4.4":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.5.tgz#7a1e1c01d28e26d1fe7f8ec9567b3b92b9d07747"
-  integrity sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==
+"@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.26.7", "@babel/types@^7.26.8", "@babel/types@^7.4.4":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.8.tgz#97dcdc190fab45be7f3dc073e3c11160d677c127"
+  integrity sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
@@ -1039,131 +1040,131 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-android-arm-eabi@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.31.0.tgz#d4dd60da0075a6ce9a6c76d71b8204f3e1822285"
-  integrity sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==
+"@rollup/rollup-android-arm-eabi@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.6.tgz#9b726b4dcafb9332991e9ca49d54bafc71d9d87f"
+  integrity sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==
 
-"@rollup/rollup-android-arm64@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.31.0.tgz#25c4d33259a7a2ccd2f52a5ffcc0bb3ab3f0729d"
-  integrity sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==
+"@rollup/rollup-android-arm64@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.6.tgz#88326ff46168a47851077ca0bf0c442689ec088f"
+  integrity sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==
 
-"@rollup/rollup-darwin-arm64@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.31.0.tgz#d137dff254b19163a6b52ac083a71cd055dae844"
-  integrity sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==
+"@rollup/rollup-darwin-arm64@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.6.tgz#b8fbcc9389bc6fad3334a1d16dbeaaa5637c5772"
+  integrity sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==
 
-"@rollup/rollup-darwin-x64@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.31.0.tgz#58ff20b5dacb797d3adca19f02a21c532f9d55bf"
-  integrity sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==
+"@rollup/rollup-darwin-x64@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.6.tgz#1aa2bcad84c0fb5902e945d88822e17a4f661d51"
+  integrity sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==
 
-"@rollup/rollup-freebsd-arm64@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.31.0.tgz#96ce1a241c591ec3e068f4af765d94eddb24e60c"
-  integrity sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==
+"@rollup/rollup-freebsd-arm64@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.6.tgz#29c54617e0929264dcb6416597d6d7481696e49f"
+  integrity sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==
 
-"@rollup/rollup-freebsd-x64@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.31.0.tgz#e59e7ede505be41f0b4311b0b943f8eb44938467"
-  integrity sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==
+"@rollup/rollup-freebsd-x64@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.6.tgz#a8b58ab7d31882559d93f2d1b5863d9e4b4b2678"
+  integrity sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.31.0.tgz#e455ca6e4ff35bd46d62201c153352e717000a7b"
-  integrity sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==
+"@rollup/rollup-linux-arm-gnueabihf@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.6.tgz#a844e1978c8b9766b169ecb1cb5cc0d8a3f05930"
+  integrity sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==
 
-"@rollup/rollup-linux-arm-musleabihf@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.31.0.tgz#bc1a93d807d19e70b1e343a5bfea43723bcd6327"
-  integrity sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==
+"@rollup/rollup-linux-arm-musleabihf@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.6.tgz#6b44c3b7257985d71b087fcb4ef01325e2fff201"
+  integrity sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==
 
-"@rollup/rollup-linux-arm64-gnu@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.31.0.tgz#f38bf843f1dc3d5de680caf31084008846e3efae"
-  integrity sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==
+"@rollup/rollup-linux-arm64-gnu@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.6.tgz#ebb499cf1720115256d0c9ae7598c90cc2251bc5"
+  integrity sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==
 
-"@rollup/rollup-linux-arm64-musl@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.31.0.tgz#b3987a96c18b7287129cf735be2dbf83e94d9d05"
-  integrity sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==
+"@rollup/rollup-linux-arm64-musl@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.6.tgz#9658221b59d9e5643348f9a52fa5ef35b4dc07b1"
+  integrity sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==
 
-"@rollup/rollup-linux-loongarch64-gnu@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.31.0.tgz#0f0324044e71c4f02e9f49e7ec4e347b655b34ee"
-  integrity sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==
+"@rollup/rollup-linux-loongarch64-gnu@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.6.tgz#19418cc57579a5655af2d850a89d74b3f7e9aa92"
+  integrity sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==
 
-"@rollup/rollup-linux-powerpc64le-gnu@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.31.0.tgz#809479f27f1fd5b4eecd2aa732132ad952d454ba"
-  integrity sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==
+"@rollup/rollup-linux-powerpc64le-gnu@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.6.tgz#fe0bce7778cb6ce86898c781f3f11369d1a4952c"
+  integrity sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==
 
-"@rollup/rollup-linux-riscv64-gnu@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.31.0.tgz#7bc75c4f22db04d3c972f83431739cfa41c6a36e"
-  integrity sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==
+"@rollup/rollup-linux-riscv64-gnu@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.6.tgz#9c158360abf6e6f7794285642ba0898c580291f6"
+  integrity sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==
 
-"@rollup/rollup-linux-s390x-gnu@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.31.0.tgz#cfe8052345c55864d83ae343362cf1912480170e"
-  integrity sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==
+"@rollup/rollup-linux-s390x-gnu@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.6.tgz#f9113498d22962baacdda008b5587d568b05aa34"
+  integrity sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==
 
-"@rollup/rollup-linux-x64-gnu@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz#c6b048f1e25f3fea5b4bd246232f4d07a159c5a0"
-  integrity sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==
+"@rollup/rollup-linux-x64-gnu@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz#aec8d4cdf911cd869a72b8bd00833cb426664e0c"
+  integrity sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==
 
-"@rollup/rollup-linux-x64-musl@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.31.0.tgz#615273ac52d1a201f4de191cbd3389016a9d7d80"
-  integrity sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==
+"@rollup/rollup-linux-x64-musl@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.6.tgz#61c0a146bdd1b5e0dcda33690dd909b321d8f20f"
+  integrity sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==
 
-"@rollup/rollup-win32-arm64-msvc@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.31.0.tgz#32ed85810c1b831c648eca999d68f01255b30691"
-  integrity sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==
+"@rollup/rollup-win32-arm64-msvc@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.6.tgz#c6c5bf290a3a459c18871110bc2e7009ce35b15a"
+  integrity sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==
 
-"@rollup/rollup-win32-ia32-msvc@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.31.0.tgz#d47effada68bcbfdccd30c4a788d42e4542ff4d3"
-  integrity sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==
+"@rollup/rollup-win32-ia32-msvc@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.6.tgz#16ca6bdadc9e054818b9c51f8dac82f6b8afab81"
+  integrity sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==
 
-"@rollup/rollup-win32-x64-msvc@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz#7a2d89a82cf0388d60304964217dd7beac6de645"
-  integrity sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==
+"@rollup/rollup-win32-x64-msvc@4.34.6":
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.6.tgz#f3d03ce2d82723eb089188ea1494a719b09e1561"
+  integrity sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==
 
 "@stonecrop/aform@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@stonecrop/aform/-/aform-0.4.3.tgz#d207d879f1a103914059001f7805fb5062d2d619"
-  integrity sha512-NwOl5kLZgL1zkiVN0Ftj6CVF+IyfsxsffHmzcifKeEVDrfrYwY000ggqBrNKKDvOICSiK4C13hn+2SCSZyngrg==
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@stonecrop/aform/-/aform-0.4.5.tgz#c1df7d1ca5c901b73150aadaf8ca7c08cee037cb"
+  integrity sha512-DdIbnEg8oqhaxnKAbasSdXy31i3XZBmvdcrtZDIhhI0ue0RhfbiCPwYnc1N6modsTCcR2Wu1Qg9OjLAVnwcu6Q==
   dependencies:
-    "@stonecrop/themes" "0.4.3"
-    "@stonecrop/utilities" "0.4.3"
+    "@stonecrop/themes" "0.4.5"
+    "@stonecrop/utilities" "0.4.5"
     "@vueuse/components" "^12.0.0"
     "@vueuse/core" "^12.0.0"
     vue "^3.5.11"
 
 "@stonecrop/beam@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@stonecrop/beam/-/beam-0.4.3.tgz#696f705550e7babab4e9c009e3ba39e8b0088c53"
-  integrity sha512-TRP9Ydki7Ii/GGhcXLg9ItG7Kdt74Hw7ufSpvr/Wp+fM40aVhhrHVE4hmw59zN2y/auAUXGbYEnIyKlcsmGmkg==
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@stonecrop/beam/-/beam-0.4.5.tgz#177a2b08f4ead9ad499664d94c9e2588550bb7cb"
+  integrity sha512-uggTZ6I+qj6n4EluwqTSN1Giy+HJA3IIOS+9QjZk3jd3ynh4612Pb/Rx8TKoDBagg44cR58yui1V/5S7nyheww==
   dependencies:
     "@vueuse/core" "^12.0.0"
     mqtt "^5.10.1"
     onscan.js "^1.5.2"
     vue "^3.5.11"
 
-"@stonecrop/themes@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@stonecrop/themes/-/themes-0.4.3.tgz#ca582850e8c0158e0ea95100683a37a7f327f08a"
-  integrity sha512-uvotcc5Z7Pge8+nbFTd5jkgBy+62qDVwPiHGXHJkE3XZ8IpPfCh19XjmzvLGduB454fdztQLHOADZoLutYbsng==
+"@stonecrop/themes@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@stonecrop/themes/-/themes-0.4.5.tgz#2b448201079dba369a56e58fb5a39c4c4a1de800"
+  integrity sha512-EZcb0LSO10Ab/ti6ZGzGbqGIH3swcZHaIxWEjO8w/0FWhwUwqmQPraVRqqy8tWjwMIQxtBHtmiI8DF1V+FUQfw==
 
-"@stonecrop/utilities@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@stonecrop/utilities/-/utilities-0.4.3.tgz#da65af10537d0ec0f8a6b4f241d9c9119c3e6b44"
-  integrity sha512-rkGe7yFXuMxtEprtLJ6CyaNQpIRdcA+DIG8p+2cNpbO7ePzxGf2PgIH7uXLw6hY1e0FVF6/6AcZBfiEyHXuBMg==
+"@stonecrop/utilities@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@stonecrop/utilities/-/utilities-0.4.5.tgz#deb5f29ebc3966955b3361a8e19454f883737983"
+  integrity sha512-VY+wR4DE8UqlaFAmfmVHhmOj8+CE4nqf7cQN+2fpxKXmvvXSwRU3DyjEfX7GPdmQOByRTvxLcKhSe/ZmASG73g==
   dependencies:
     "@vueuse/core" "^12.0.0"
     vue "^3.5.11"
@@ -1188,17 +1189,22 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
+"@types/gensync@^1.0.0":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/gensync/-/gensync-1.0.4.tgz#7122d8f0cd3bf437f9725cc95b180197190cf50b"
+  integrity sha512-C3YYeRQWp2fmq9OryX+FoDy8nXS6scQ7dPptD8LnFDAUNcKWJjXQKDNJD3HVm+kOUsXhTOkpi69vI4EuAr95bA==
+
 "@types/node@*":
-  version "22.10.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.10.tgz#85fe89f8bf459dc57dfef1689bd5b52ad1af07e6"
-  integrity sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==
+  version "22.13.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.1.tgz#a2a3fefbdeb7ba6b89f40371842162fac0934f33"
+  integrity sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==
   dependencies:
     undici-types "~6.20.0"
 
 "@types/node@^20.12.12":
-  version "20.17.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.16.tgz#b33b0edc1bf925b27349e494b871ca4451fabab4"
-  integrity sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==
+  version "20.17.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.17.tgz#5cea2af2e271313742c14f418eaf5dcfa8ae2e3a"
+  integrity sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==
   dependencies:
     undici-types "~6.19.2"
 
@@ -1485,13 +1491,13 @@ babel-plugin-polyfill-corejs2@^0.4.10:
     "@babel/helper-define-polyfill-provider" "^0.6.3"
     semver "^6.3.1"
 
-babel-plugin-polyfill-corejs3@^0.10.6:
-  version "0.10.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz#2deda57caef50f59c525aeb4964d3b2f867710c7"
-  integrity sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==
+babel-plugin-polyfill-corejs3@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz#4e4e182f1bb37c7ba62e2af81d8dd09df31344f6"
+  integrity sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.6.2"
-    core-js-compat "^3.38.0"
+    "@babel/helper-define-polyfill-provider" "^0.6.3"
+    core-js-compat "^3.40.0"
 
 babel-plugin-polyfill-regenerator@^0.6.1:
   version "0.6.3"
@@ -1516,9 +1522,9 @@ binary-extensions@^2.0.0:
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
 bl@^6.0.8:
-  version "6.0.18"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-6.0.18.tgz#eaf008d00fbb53eaade7ffc2fb8c527b9f66ead5"
-  integrity sha512-2k76XmWCuvu9HTvu3tFOl5HDdCH0wLZ/jHYva/LBVJmc9oX8yUtNQjxrFmbTdXsCSmIxwVTANZPNDfMQrvHFUw==
+  version "6.0.19"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-6.0.19.tgz#c4487282bb18768186f02fec6be1be3b5b93677b"
+  integrity sha512-4Ay3A3oDfGg3GGirhl4s62ebtnk0pJZA5mLp672MPKOQXsWvXjEF4dqdXySjJIs7b9OVr/O8aOo0Lm+xdjo2JA==
   dependencies:
     "@types/readable-stream" "^4.0.0"
     buffer "^6.0.3"
@@ -1597,9 +1603,9 @@ call-bound@^1.0.2, call-bound@^1.0.3:
     get-intrinsic "^1.2.6"
 
 caniuse-lite@^1.0.30001688:
-  version "1.0.30001695"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz#39dfedd8f94851132795fdf9b79d29659ad9c4d4"
-  integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
+  version "1.0.30001699"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz#a102cf330d153bf8c92bfb5be3cd44c0a89c8c12"
+  integrity sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==
 
 chalk@^4.0.2:
   version "4.1.2"
@@ -1676,7 +1682,7 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-core-js-compat@^3.38.0, core-js-compat@^3.38.1:
+core-js-compat@^3.40.0:
   version "3.40.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.40.0.tgz#7485912a5a4a4315c2fdb2cbdc623e6881c88b38"
   integrity sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==
@@ -1781,9 +1787,9 @@ ejs@^3.1.6:
     jake "^10.8.5"
 
 electron-to-chromium@^1.5.73:
-  version "1.5.87"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.87.tgz#3a89bec85e43a8b32445ec938228e4ec982e0f79"
-  integrity sha512-mPFwmEWmRivw2F8x3w3l2m6htAUN97Gy0kwpO++2m9iT1Gt8RCFVUfv9U/sIbHJ6rY4P6/ooqFL/eL7ock+pPg==
+  version "1.5.97"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz#5c4a4744c79e7c85b187adf5160264ac130c776f"
+  integrity sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1987,9 +1993,9 @@ fast-uri@^3.0.1:
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
 fastq@^1.6.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.18.0.tgz#d631d7e25faffea81887fe5ea8c9010e1b36fee0"
-  integrity sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.0.tgz#a82c6b7c2bb4e44766d865f07997785fecfdcb89"
+  integrity sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==
   dependencies:
     reusify "^1.0.4"
 
@@ -2013,11 +2019,11 @@ fill-range@^7.1.1:
     to-regex-range "^5.0.1"
 
 for-each@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
+  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
-    is-callable "^1.1.3"
+    is-callable "^1.2.7"
 
 foreground-child@^3.1.0:
   version "3.3.0"
@@ -2281,14 +2287,14 @@ is-binary-path@~2.1.0:
     binary-extensions "^2.0.0"
 
 is-boolean-object@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.1.tgz#c20d0c654be05da4fbc23c562635c019e93daf89"
-  integrity sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz#7067f47709809a393c71ff5bb3e135d8a9215d9e"
+  integrity sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==
   dependencies:
-    call-bound "^1.0.2"
+    call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
-is-callable@^1.1.3, is-callable@^1.2.7:
+is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
@@ -2441,11 +2447,11 @@ is-weakmap@^2.0.2:
   integrity sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==
 
 is-weakref@^1.0.2, is-weakref@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.1.0.tgz#47e3472ae95a63fa9cf25660bcf0c181c39770ef"
-  integrity sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.1.1.tgz#eea430182be8d64174bd96bffbc46f21bf3f9293"
+  integrity sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==
   dependencies:
-    call-bound "^1.0.2"
+    call-bound "^1.0.3"
 
 is-weakset@^2.0.3:
   version "2.0.4"
@@ -2466,9 +2472,9 @@ isexe@^2.0.0:
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 jackspeak@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.0.2.tgz#11f9468a3730c6ff6f56823a820d7e3be9bef015"
-  integrity sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.0.3.tgz#8a21082b8c019e7a0a8187ad8b736609bc85ab18"
+  integrity sha512-oSwM7q8PTHQWuZAlp995iPpPJ4Vkl7qT0ZRD+9duL9j2oBy6KcTfyxc8mEuHJYC+z/kbps80aJLkaNzTOrf/kw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
 
@@ -2731,9 +2737,9 @@ number-allocator@^1.0.14:
     js-sdsl "4.3.0"
 
 object-inspect@^1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
-  integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
+  integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -2807,9 +2813,9 @@ pathe@^1.1.2:
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
 
 pathe@^2.0.1, pathe@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.2.tgz#5ed86644376915b3c7ee4d00ac8c348d671da3a5"
-  integrity sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
@@ -2844,14 +2850,14 @@ pkg-types@^1.2.1, pkg-types@^1.3.0:
     pathe "^2.0.1"
 
 possible-typed-array-names@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
-  integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
+  integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
 postcss@^8.4.43, postcss@^8.4.48:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.1.tgz#e2272a1f8a807fafa413218245630b5db10a3214"
-  integrity sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.2.tgz#e7b99cb9d2ec3e8dd424002e7c16517cb2b846bd"
+  integrity sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==
   dependencies:
     nanoid "^3.3.8"
     picocolors "^1.1.1"
@@ -3032,31 +3038,31 @@ rollup@^2.43.1:
     fsevents "~2.3.2"
 
 rollup@^4.20.0:
-  version "4.31.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.31.0.tgz#b84af969a0292cb047dce2c0ec5413a9457597a4"
-  integrity sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==
+  version "4.34.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.34.6.tgz#a07e4d2621759e29034d909655e7a32eee9195c9"
+  integrity sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==
   dependencies:
     "@types/estree" "1.0.6"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.31.0"
-    "@rollup/rollup-android-arm64" "4.31.0"
-    "@rollup/rollup-darwin-arm64" "4.31.0"
-    "@rollup/rollup-darwin-x64" "4.31.0"
-    "@rollup/rollup-freebsd-arm64" "4.31.0"
-    "@rollup/rollup-freebsd-x64" "4.31.0"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.31.0"
-    "@rollup/rollup-linux-arm-musleabihf" "4.31.0"
-    "@rollup/rollup-linux-arm64-gnu" "4.31.0"
-    "@rollup/rollup-linux-arm64-musl" "4.31.0"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.31.0"
-    "@rollup/rollup-linux-powerpc64le-gnu" "4.31.0"
-    "@rollup/rollup-linux-riscv64-gnu" "4.31.0"
-    "@rollup/rollup-linux-s390x-gnu" "4.31.0"
-    "@rollup/rollup-linux-x64-gnu" "4.31.0"
-    "@rollup/rollup-linux-x64-musl" "4.31.0"
-    "@rollup/rollup-win32-arm64-msvc" "4.31.0"
-    "@rollup/rollup-win32-ia32-msvc" "4.31.0"
-    "@rollup/rollup-win32-x64-msvc" "4.31.0"
+    "@rollup/rollup-android-arm-eabi" "4.34.6"
+    "@rollup/rollup-android-arm64" "4.34.6"
+    "@rollup/rollup-darwin-arm64" "4.34.6"
+    "@rollup/rollup-darwin-x64" "4.34.6"
+    "@rollup/rollup-freebsd-arm64" "4.34.6"
+    "@rollup/rollup-freebsd-x64" "4.34.6"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.34.6"
+    "@rollup/rollup-linux-arm-musleabihf" "4.34.6"
+    "@rollup/rollup-linux-arm64-gnu" "4.34.6"
+    "@rollup/rollup-linux-arm64-musl" "4.34.6"
+    "@rollup/rollup-linux-loongarch64-gnu" "4.34.6"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.34.6"
+    "@rollup/rollup-linux-riscv64-gnu" "4.34.6"
+    "@rollup/rollup-linux-s390x-gnu" "4.34.6"
+    "@rollup/rollup-linux-x64-gnu" "4.34.6"
+    "@rollup/rollup-linux-x64-musl" "4.34.6"
+    "@rollup/rollup-win32-arm64-msvc" "4.34.6"
+    "@rollup/rollup-win32-ia32-msvc" "4.34.6"
+    "@rollup/rollup-win32-x64-msvc" "4.34.6"
     fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
@@ -3397,9 +3403,9 @@ tempy@^0.6.0:
     unique-string "^2.0.0"
 
 terser@^5.17.4:
-  version "5.37.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.37.0.tgz#38aa66d1cfc43d0638fab54e43ff8a4f72a21ba3"
-  integrity sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==
+  version "5.38.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.38.2.tgz#24aef4ea48c900d46a4b13f6a53789980d59967f"
+  integrity sha512-w8CXxxbFA5zfNsR/i8HZq5bvn18AK0O9jj7hyo1YqkovLxEFa0uP0LCVGZRqiRaKRFxXhELBp8SteeAjEnfeJg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"


### PR DESCRIPTION
# Repack Page

### Mappers:
First, I need to work with `store.cache.mappers`. This is because when you scan an item or a warehouse, the data is stored there. So, I modified this line in `scan.ts`:

```javascript
const documentId = computed(() => {
   const currentRoute = store.router.currentRoute.value
   return currentRoute.params.id || currentRoute.query.id || **store.router.currentRoute.value?.name** || ''
})
```

When you are on the **Move** or **Repack** pages (which do not have an `id`), the route path is used to determine the current page.

With this approach, the data for the Move and Repack pages remain separate.

### Repack
![Screenshot 2025-02-11 at 1 55 57 PM](https://github.com/user-attachments/assets/9068236b-fb7b-4681-a456-07c448f28694)

The page has:
- **Item to Repack** - Link - is an async dropdown, so you need to start typing or scan an item to search for it.
- **Qty** - A component from `aform`. I still need to work on its styles.
- **BOM** (Optional) - Link - A dropdown list populated when entering the page. It automatically fills the item list with all the BOM items. (Demo below)
- **Source Warehouse** - Link - Can be selected manually or scanned.
- **Target Warehouse** - Link - Can be selected manually or scanned.
- Items list -ListView - Filled when click the **Add** button

https://github.com/user-attachments/assets/791b0279-7813-4a21-873b-4bff512461ba

### Store
I added the function `getStockEntryItems` to retrieve the items when selecting a BOM. To fetch this data, I call the ERPNext method `get_bom_items`.

The data returned by this method is typed as `BomItem` in `types/frappe.ts`.

### Demo

https://github.com/user-attachments/assets/e86afb1b-61bb-4d50-9de1-17b22b5a0e89


### TODO
I'm working on the BOM feature. There are still some bugs when saving a repack populated via BOM.
