### PR TITLE
Add completed_qty to test fixtures 

### DIFF
--- a/beam/beam/overrides/inventory_dimension.py
+++ b/beam/beam/overrides/inventory_dimension.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024, AgriTheory and contributors
+# For license information, please see license.txt
+
 from beam.beam.demand.demand import build_demand_allocation_map
 from beam.beam.demand.receiving import reset_build_receiving_map
 

--- a/beam/beam/scan/user_login.py
+++ b/beam/beam/scan/user_login.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024, AgriTheory and contributors
+# For license information, please see license.txt
+
 import frappe
 from erpnext import get_default_company
 from frappe.core.doctype.user.user import get_restricted_ip_list

--- a/beam/tests/setup.py
+++ b/beam/tests/setup.py
@@ -702,14 +702,13 @@ def create_production_plan(settings, prod_plan_from_doc):
 			job_card.append(
 				"time_logs",
 				{
-					"completed_qty": wo.qty,
+					#"completed_qty": wo.qty,
 					"from_time": start_time,
 					"to_time": start_time + datetime.timedelta(minutes=time_in_mins),
 					"time_in_mins": time_in_mins,
 					"remaining_time_in_mins": time_in_mins,
 				},
 			)
-			job_card.is_corrective_job_card = 1
 			job_card.save()
 			start_time = job_card.time_logs[0].to_time + datetime.timedelta(minutes=2)
 			# job_card.submit() # TODO: don't submit for demand tests

--- a/beam/tests/setup.py
+++ b/beam/tests/setup.py
@@ -709,6 +709,7 @@ def create_production_plan(settings, prod_plan_from_doc):
 					"remaining_time_in_mins": time_in_mins,
 				},
 			)
+			job_card.is_corrective_job_card = 1
 			job_card.save()
 			start_time = job_card.time_logs[0].to_time + datetime.timedelta(minutes=2)
 			# job_card.submit() # TODO: don't submit for demand tests

--- a/beam/tests/setup.py
+++ b/beam/tests/setup.py
@@ -702,7 +702,7 @@ def create_production_plan(settings, prod_plan_from_doc):
 			job_card.append(
 				"time_logs",
 				{
-					#"completed_qty": wo.qty,
+					# "completed_qty": wo.qty,
 					"from_time": start_time,
 					"to_time": start_time + datetime.timedelta(minutes=time_in_mins),
 					"time_in_mins": time_in_mins,

--- a/beam/www/beam/utils/error.ts
+++ b/beam/www/beam/utils/error.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024, AgriTheory and contributors
+// For license information, please see license.txt
+
 import type { FrappeResponse } from '@/types/frappe.js'
 import { useBeamToast } from '@/utils/toast.js'
 

--- a/beam/www/beam/utils/toast.ts
+++ b/beam/www/beam/utils/toast.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024, AgriTheory and contributors
+// For license information, please see license.txt
+
 import { type ToastProps, useToast } from 'vue-toast-notification'
 import 'vue-toast-notification/dist/theme-default.css'
 


### PR DESCRIPTION
ERPNext has updated recently: https://github.com/frappe/erpnext/pull/48745

If you try to execute bench execute 'beam.tests.setup.before_test' with ERPNext updated to v15.71.1, it will throw an error:

<img width="1370" height="577" alt="Screenshot 2025-07-24 at 1 40 00 PM" src="https://github.com/user-attachments/assets/d1777afc-6e0a-45b7-9813-efd2f6aa590e" />

`erpnext.manufacturing.doctype.job_card.job_card.OperationSequenceError: Job Card PO-JOB00002: As per the sequence of the operations in the work order MFG-WO-2025-00001, complete the operation Gather Pie Filling Ingredients before the operation Cook Pie Filling Operation.`

This error occurs because Work Order has a new function,`validate_operations_sequence`:

https://github.com/frappe/erpnext/blob/3825490f0dbbd5530b739e928d012f639b6efafe/erpnext/manufacturing/doctype/work_order/work_order.py#L173

This function assigns`sequence_id` to all operations that don't have one assigned, and then we have this function:

https://github.com/frappe/erpnext/blob/ad45063c76880a443c772a0ea3aa7ab6ca33da3c/erpnext/manufacturing/doctype/job_card/job_card.py#L1032

That function was created one year ago, but it wasn't a problem because it has this condition:

```js
    if not (self.work_order and self.sequence_id):
        return
```

Since we didn't assign`sequence_id` to our operations, this validation wasn't a problem.

But this function has a condition before:

```js
	def validate_sequence_id(self):
		if self.is_corrective_job_card:
			return
```

That is the reason for my change.
