### PR TITLE
[mobile] Fix redirect to Beam

### DIFF
--- a/beam/beam/boot.py
+++ b/beam/beam/boot.py
@@ -16,7 +16,8 @@ def boot_session(bootinfo):
 
 
 def redirect_to_beam():
-	user_roles = frappe.get_roles(frappe.session.user)
-
+	user_roles = frappe.get_all(
+		"Has Role", fields=["role"], filters={"parent": frappe.session.user}, pluck="role"
+	)
 	if "BEAM Mobile User" in user_roles:
 		frappe.local.response["home_page"] = "/beam#/"


### PR DESCRIPTION
## get_roles method

Although the Administrator user does not have the `BEAM Mobile User` role:

<img width="1547" height="995" alt="Screenshot 2025-12-02 at 12 09 30 PM" src="https://github.com/user-attachments/assets/cb5beeab-5c47-4340-95c3-19d9337de2b1" />

`frappe.get_roles` still includes it:

<img width="578" height="362" alt="Screenshot 2025-12-02 at 12 11 08 PM" src="https://github.com/user-attachments/assets/25d72612-f0bf-4cc8-92ac-f65aa58d2bab" />


## get_all method

Using `frappe.get_all` to fetch the user's roles works:

<img width="850" height="119" alt="Screenshot 2025-12-02 at 12 12 31 PM" src="https://github.com/user-attachments/assets/b9d50279-11d3-4480-ac81-eb6286dce401" />

## Another example

Test with a user who *does* have the `BEAM Mobile User` role:

<img width="1432" height="940" alt="Screenshot 2025-12-02 at 12 13 35 PM" src="https://github.com/user-attachments/assets/7539e022-c921-410f-af9b-388899fbe91a" />

<img width="842" height="81" alt="Screenshot 2025-12-02 at 12 13 42 PM" src="https://github.com/user-attachments/assets/4ca2f398-25db-45e8-98d8-93c00d7c5451" />

