### PR TITLE
feat: beam_barcode_resolver hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         additional_dependencies: ['flake8-bugbear']
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v1.20.1
+    rev: v1.20.2
     hooks:
       - id: update_pre_commit_config
       - id: validate_frappe_project

--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -83,6 +83,13 @@ def get_barcode_context(barcode: str) -> frappe._dict | None:
 					"barcode": barcode,
 				}
 			)
+
+	# Fallback: custom barcode resolvers registered by other apps via beam_barcode_resolver hook
+	for resolver in frappe.get_hooks("beam_barcode_resolver"):
+		result = frappe.call(resolver, barcode=barcode)
+		if result:
+			return result
+
 	return None
 
 
@@ -212,12 +219,27 @@ def get_list_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 
 def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[dict[str, Any]]:
 	target = None
+	beam_override = frappe.get_hooks("beam_frm")
+	has_frm_override = bool(
+		beam_override
+		and beam_override.get(barcode_doc.doc.doctype, {}).get(context.frm)
+	)
+
 	if barcode_doc.doc.doctype == "Handling Unit":
 		hu_details = get_handling_unit(barcode_doc.doc.name, context.frm)
 		if context.frm == "Stock Entry":
 			target = get_stock_entry_item_details(context.doc, hu_details.item_code)
 			target.warehouse = hu_details.warehouse
 		elif context.frm in ("Putaway Rule", "Warranty Claim", "Item Price", "Quality Inspection"):
+			target = frappe._dict(
+				{
+					"doctype": context.frm,
+					"item_code": hu_details.item_code,
+				}
+			)
+		elif has_frm_override:
+			# A beam_frm override handles this form - skip get_item_details() which would
+			# fail for forms without a standard "{doctype} Item" child table.
 			target = frappe._dict(
 				{
 					"doctype": context.frm,
@@ -249,6 +271,15 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 		if context.frm == "Stock Entry":
 			target = get_stock_entry_item_details(context.doc, barcode_doc.doc.name)
 		elif context.frm in ("Putaway Rule", "Warranty Claim", "Item Price", "Quality Inspection"):
+			target = frappe._dict(
+				{
+					"doctype": context.frm,
+					"item_code": barcode_doc.doc.name,
+				}
+			)
+		elif has_frm_override:
+			# A beam_frm override handles this form — skip get_item_details() which would
+			# fail for forms without a standard "{doctype} Item" child table.
 			target = frappe._dict(
 				{
 					"doctype": context.frm,
@@ -312,8 +343,6 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 
 	if not target:
 		return []
-
-	beam_override = frappe.get_hooks("beam_frm")
 
 	if beam_override:
 		override_doctype = beam_override.get(barcode_doc.doc.doctype)

--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -221,8 +221,7 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 	target = None
 	beam_override = frappe.get_hooks("beam_frm")
 	has_frm_override = bool(
-		beam_override
-		and beam_override.get(barcode_doc.doc.doctype, {}).get(context.frm)
+		beam_override and beam_override.get(barcode_doc.doc.doctype, {}).get(context.frm)
 	)
 
 	if barcode_doc.doc.doctype == "Handling Unit":


### PR DESCRIPTION
Add extension points to BEAM's scan pipeline so that other apps can handle barcode scans on custom forms

#### New hooks

- `beam_barcode_resolver`:
Fallback barcode resolution for doctypes that aren't Item, Handling Unit, or standard ERPNext barcodes. Apps register a resolver function that receives the barcode string and returns a `frappe._dict(doc=..., barcode=...)` or `None`.

- `beam_frm` override in `get_form_action()`:
When a scanned Handling Unit or Item lands on a form that doesn't have a standard `{Doctype} Item` child table, `get_item_details()` would fail with a 404. The new `has_frm_override` check skips that call and builds a minimal target instead.