### PR TITLE
fix: ensure CI fails when pytest fails by adding pipefail

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -83,6 +83,7 @@ jobs:
       - name: Run Tests
         working-directory: /home/runner/frappe-bench
         run: |
+          set -o pipefail
           source env/bin/activate
           cd apps/beam
           poetry install

--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -279,9 +279,7 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 		elif has_frm_override:
 			# A beam_frm override handles this form — skip get_item_details() which would
 			# fail for forms without a standard "{doctype} Item" child table.
-			item_defaults = frappe.db.get_value(
-				"Item", barcode_doc.doc.name, ["stock_uom"], as_dict=True
-			)
+			item_defaults = frappe.db.get_value("Item", barcode_doc.doc.name, ["stock_uom"], as_dict=True)
 			target = frappe._dict(
 				{
 					"doctype": context.frm,

--- a/beam/beam/scan/__init__.py
+++ b/beam/beam/scan/__init__.py
@@ -279,10 +279,14 @@ def get_form_action(barcode_doc: frappe._dict, context: frappe._dict) -> list[di
 		elif has_frm_override:
 			# A beam_frm override handles this form — skip get_item_details() which would
 			# fail for forms without a standard "{doctype} Item" child table.
+			item_defaults = frappe.db.get_value(
+				"Item", barcode_doc.doc.name, ["stock_uom"], as_dict=True
+			)
 			target = frappe._dict(
 				{
 					"doctype": context.frm,
 					"item_code": barcode_doc.doc.name,
+					"uom": item_defaults.stock_uom if item_defaults else None,
 				}
 			)
 		else:


### PR DESCRIPTION
Bash pipelines (|) return the exit code of the last command by default. By enabling set -o pipefail, the pipeline fails if any command fails.

This ensures that the workflow correctly fails when pytest fails.

This behavior is already present in the`mobile_v15` branch, but was missing in the current target branch.